### PR TITLE
[FICTIUM-005] Add Rspec integration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     fictium (0.1.0)
       activesupport (>= 5.3, < 6.2)
+      verbs (~> 2.1.4)
 
 GEM
   remote: https://rubygems.org/
@@ -179,6 +180,9 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
+    verbs (2.1.4)
+      activesupport (>= 2.3.4)
+      i18n
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)

--- a/README.md
+++ b/README.md
@@ -44,11 +44,39 @@ The document, then is divided in resources. The class [Fictium::Resource](./lib/
 
 Each resource is sub divided in actions, [Fictium::Action](./lib/fictoum/poros/fictium/action). Actions are enpoints associated with a REST method.
 
+### Configuration
+
+This gem attemps to complete the documentation for you, so you don't have to constantly document it yourself.
+To configure how this gem completes your documentation, you have some nice configurations available:
+
+TODO: Describe possible configurations and each value
+
 ### RSpec Integration
 
-Just add the following file fictium/rspec. And your RSpec test will run for free.
+Just `require 'fictium/rspec'` in your spec helper and your RSpec test will include everything you need to work in your environment.
 
-[TODO: Add examples of using RSpec here!]
+At any test of type: :controller, you can just add the following helpers:
+
+```rb
+describe PostsController do
+  describe action 'GET #index' do
+    describe example 'without errors' do
+        default_example # You can select an example to be marked as default in your action
+
+        before do
+            get :index
+        end
+
+        # ... your tests
+    end
+  end
+end
+```
+
+The idea, is that your controller has actions, and each actions has examples.
+You can, for now, check `spec/controllers` at this repository to
+
+TODO: Go deeper to explain default overrides
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,8 @@ Each resource is sub divided in actions, [Fictium::Action](./lib/fictoum/poros/f
 ### Configuration
 
 This gem attemps to complete the documentation for you, so you don't have to constantly document it yourself.
-To configure how this gem completes your documentation, you have some nice configurations available:
+To configure how this gem completes your documentation, you have some configurations available [here](https://github.com/Wolox/fictium/wiki).
 
-TODO: Describe possible configurations and each value
 
 ### RSpec Integration
 

--- a/fictium.gemspec
+++ b/fictium.gemspec
@@ -33,6 +33,8 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
                               Fictium::RAILS_MIN_VERSION,
                               Fictium::RAILS_MAX_VERSION
 
+  spec.add_runtime_dependency 'verbs', '~> 2.1.4'
+
   spec.add_development_dependency 'bundler', '~> 2.0'
 
   spec.add_development_dependency 'byebug'

--- a/lib/fictium.rb
+++ b/lib/fictium.rb
@@ -15,11 +15,12 @@ end
 
 module Fictium
   class << self
-    attr_reader :configuration
+    def configuration
+      @configuration ||= Fictium::Configuration.new
+    end
 
     def configure
-      @configuration ||= Fictium::Configuration.new
-      yield @configuration
+      yield configuration
     end
   end
 end

--- a/lib/fictium/configurations/configuration.rb
+++ b/lib/fictium/configurations/configuration.rb
@@ -1,7 +1,7 @@
 module Fictium
   class Configuration
     VOWEL = /[aeiou]/i.freeze
-    VERB_TERMINATOR = /[hstv]/i.freeze
+    private_constant :VOWEL
 
     attr_accessor :exporters, :summary_format, :default_action_descriptors,
                   :unknown_action_descriptor, :default_subject

--- a/lib/fictium/configurations/configuration.rb
+++ b/lib/fictium/configurations/configuration.rb
@@ -1,10 +1,62 @@
 module Fictium
   class Configuration
-    attr_accessor :exporters
+    VOWEL = /[aeiou]/i.freeze
+    VERB_TERMINATOR = /[hstv]/i.freeze
+
+    attr_accessor :exporters, :summary_format, :default_action_descriptors,
+                  :unknown_action_descriptor, :default_subject
 
     def initialize
       # TODO: Add default exporter in exporter list
       @exporters = []
+
+      @summary_format = method(:default_summary_format)
+      @default_action_descriptors = {
+        default_summary_for_index: method(:default_summary_for_index),
+        default_summary_for_show: method(:default_summary_for_show),
+        default_summary_for_update: method(:default_summary_for_update),
+        default_summary_for_destroy: method(:default_summary_for_destroy)
+      }
+      @unknown_action_descriptor = method(:default_unknown_action_descriptor)
+      @default_subject = 'This endpoint'
+    end
+
+    private
+
+    def default_summary_format(resources)
+      "Handles API #{resources}."
+    end
+
+    def default_unknown_action_descriptor(action, action_name)
+      name = action_name.humanize
+      "#{conjugate(name)} an existing #{action.resource.name}."
+    end
+
+    def default_summary_for_index(action)
+      "#{default_subject} lists all available #{action.resource.name.pluralize}"
+    end
+
+    def default_summary_for_show(action)
+      name = action.resource.name
+      "#{default_subject} shows details of #{get_preposition(name)} #{name}."
+    end
+
+    def default_summary_for_update(action)
+      name = action.resource.name
+      "#{default_subject} updates #{get_preposition(name)} #{name}."
+    end
+
+    def default_summary_for_destroy(action)
+      name = action.resource.name
+      "#{default_subject} destroys #{get_preposition(name)} #{name}."
+    end
+
+    def conjugate(name)
+      ::Verbs::Conjugator.conjugate name, subject: default_subject, tense: :present, person: :third
+    end
+
+    def get_preposition(resource_name)
+      resource_name.start_with?(VOWEL) ? 'an' : 'a'
     end
   end
 end

--- a/lib/fictium/poros/action.rb
+++ b/lib/fictium/poros/action.rb
@@ -1,5 +1,15 @@
 module Fictium
   class Action < Fictium::Model
+    ACTION_NAME = /#([A-Z_]+)/i.freeze
+    PATH_METHODS = /$(get|post|put|patch|delete)/i.freeze
+    DEFAULT_PATHS = {
+      create: '',
+      new: '/new',
+      show: '/:id',
+      update: '/:id',
+      destroy: '/:id'
+    }.freeze
+
     attr_reader :resource, :examples
     attr_accessor :path, :summary, :description, :method
 
@@ -24,6 +34,45 @@ module Fictium
 
     def add_example
       Fictium::Example.new(self).tap { |example| examples << example }
+    end
+
+    def description_attributes(description)
+      name = find_action_name(description)&.downcase
+      find_summary(name)
+      find_path(name)
+      find_method(description)
+    end
+
+    private
+
+    def find_summary(name)
+      return if name.blank?
+
+      key = :"default_summary_for_#{name}"
+      summary_method = descriptors[key] || Fictium.configuration.unknown_action_descriptor
+      one_argument = summary_method.arity == 1
+      self.summary = one_argument ? summary_method.call(self) : summary_method.call(self, name)
+    end
+
+    def descriptors
+      @descriptors ||= Fictium.configuration.default_action_descriptors || {}
+    end
+
+    def find_method(description)
+      match = description.match(PATH_METHODS)
+      self.method = match.presence && match[1]&.downcase
+    end
+
+    def find_path(name)
+      return if name.blank?
+
+      key = name.to_sym
+      self.path = DEFAULT_PATHS[key].presence || "/:id/#{name}"
+    end
+
+    def find_action_name(description)
+      match = description.match(ACTION_NAME)
+      match.presence && match[1]
     end
   end
 end

--- a/lib/fictium/poros/action.rb
+++ b/lib/fictium/poros/action.rb
@@ -5,9 +5,9 @@ module Fictium
     DEFAULT_PATHS = {
       create: '',
       new: '/new',
-      show: '/:id',
-      update: '/:id',
-      destroy: '/:id'
+      show: '/{id}',
+      update: '/{id}',
+      destroy: '/{id}'
     }.freeze
 
     attr_reader :resource, :examples
@@ -67,7 +67,7 @@ module Fictium
       return if name.blank?
 
       key = name.to_sym
-      self.path = DEFAULT_PATHS[key].presence || "/:id/#{name}"
+      self.path = DEFAULT_PATHS[key].presence || "/{id}/#{name}"
     end
 
     def find_action_name(description)

--- a/lib/fictium/poros/document.rb
+++ b/lib/fictium/poros/document.rb
@@ -9,5 +9,11 @@ module Fictium
     def create_resource
       Fictium::Resource.new(self).tap { |resource| resources << resource }
     end
+
+    def export
+      Fictium.configuration.exporters.each do |exporter|
+        exporter.export(self)
+      end
+    end
   end
 end

--- a/lib/fictium/poros/example.rb
+++ b/lib/fictium/poros/example.rb
@@ -1,7 +1,7 @@
 module Fictium
   class Example < Fictium::Model
     attr_reader :action
-    attr_accessor :status_code, :response_body, :content_type, :default
+    attr_accessor :summary, :description, :status_code, :response_body, :content_type, :default
 
     def initialize(action)
       @action = action

--- a/lib/fictium/poros/example.rb
+++ b/lib/fictium/poros/example.rb
@@ -1,10 +1,20 @@
 module Fictium
   class Example < Fictium::Model
     attr_reader :action
-    attr_accessor :status_code, :response_body, :content_type
+    attr_accessor :status_code, :response_body, :content_type, :default
 
     def initialize(action)
       @action = action
+    end
+
+    def process_http_response(response)
+      self.status_code = response.status
+      self.response_body = response.body
+      self.content_type = response.content_type
+    end
+
+    def default?
+      default
     end
   end
 end

--- a/lib/fictium/poros/resource.rb
+++ b/lib/fictium/poros/resource.rb
@@ -1,15 +1,27 @@
 module Fictium
   class Resource < Fictium::Model
+    REVERSE_CONTROLLER = 'Controller'.reverse.freeze
+
     attr_reader :document, :actions
     attr_accessor :name, :base_path, :summary, :description, :tags
 
     def initialize(document)
       @document = document
       @actions = []
+      @tags = []
     end
 
     def create_action
       Fictium::Action.new(self).tap { |action| actions << action }
+    end
+
+    def name_attributes(controller_name)
+      resource_path = controller_name.reverse.sub(REVERSE_CONTROLLER, '').reverse.underscore
+      self.base_path = "/#{resource_path}"
+      path_sections = resource_path.split('/')
+      plural = path_sections.last
+      self.name = plural.singularize.humanize(capitalize: false)
+      self.summary = Fictium.configuration.summary_format.call(plural)
     end
   end
 end

--- a/lib/fictium/poros/resource.rb
+++ b/lib/fictium/poros/resource.rb
@@ -1,6 +1,6 @@
 module Fictium
   class Resource < Fictium::Model
-    REVERSE_CONTROLLER = 'Controller'.reverse.freeze
+    CONTROLLER_TERMINATION = /Controller$/.freeze
 
     attr_reader :document, :actions
     attr_accessor :name, :base_path, :summary, :description, :tags
@@ -16,7 +16,7 @@ module Fictium
     end
 
     def name_attributes(controller_name)
-      resource_path = controller_name.reverse.sub(REVERSE_CONTROLLER, '').reverse.underscore
+      resource_path = controller_name.sub(CONTROLLER_TERMINATION, '').underscore
       self.base_path = "/#{resource_path}"
       path_sections = resource_path.split('/')
       plural = path_sections.last

--- a/lib/fictium/rspec.rb
+++ b/lib/fictium/rspec.rb
@@ -1,0 +1,34 @@
+require 'fictium'
+require 'rspec'
+require 'verbs'
+
+require_relative 'rspec/proxy_handler'
+
+require_relative 'rspec/resources'
+require_relative 'rspec/actions'
+require_relative 'rspec/examples'
+
+require_relative 'rspec/proxies/base'
+require_relative 'rspec/proxies/action'
+require_relative 'rspec/proxies/example'
+
+module Fictium
+  module RSpec
+    class << self
+      def document
+        @document ||= Fictium::Document.new
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.extend Fictium::RSpec::ProxyHandler
+  config.include Fictium::RSpec::Resources, type: :controller
+  config.include Fictium::RSpec::Actions, fictium_action: true
+  config.include Fictium::RSpec::Examples, fictium_example: true
+
+  config.after(:suite) do
+    Fictium::RSpec.document.export
+  end
+end

--- a/lib/fictium/rspec/actions.rb
+++ b/lib/fictium/rspec/actions.rb
@@ -1,0 +1,26 @@
+module Fictium
+  module RSpec
+    module Actions
+      extend ActiveSupport::Concern
+
+      included do
+        metadata[:fictium_action] = metadata[:fictium_resource].create_action
+        metadata[:fictium_action].description_attributes(metadata[:description])
+      end
+
+      class_methods do
+        def path(path)
+          metadata[:fictium_action].path = path
+        end
+
+        def params_in(section, &block)
+          metadata[:fictium_action].add_params_in(section, &block)
+        end
+
+        def example(*args, **kwargs)
+          Fictium::RSpec::Proxies::Example.new(self, args, kwargs)
+        end
+      end
+    end
+  end
+end

--- a/lib/fictium/rspec/examples.rb
+++ b/lib/fictium/rspec/examples.rb
@@ -5,6 +5,7 @@ module Fictium
 
       included do
         metadata[:fictium_example] = metadata[:fictium_action].add_example
+        metadata[:fictium_example].summary = metadata[:description]
 
         context 'with documentation' do
           let(:metadata) { self.class.metadata }

--- a/lib/fictium/rspec/examples.rb
+++ b/lib/fictium/rspec/examples.rb
@@ -1,0 +1,26 @@
+module Fictium
+  module RSpec
+    module Examples
+      extend ActiveSupport::Concern
+
+      included do
+        metadata[:fictium_example] = metadata[:fictium_action].add_example
+
+        context 'with documentation' do
+          let(:metadata) { self.class.metadata }
+
+          it 'documents the example' do
+            expect(metadata[:fictium_example]).to be_present
+            metadata[:fictium_example].process_http_response(response)
+          end
+        end
+      end
+
+      class_methods do
+        def default_example
+          metadata[:fictium_example].default = true
+        end
+      end
+    end
+  end
+end

--- a/lib/fictium/rspec/proxies/action.rb
+++ b/lib/fictium/rspec/proxies/action.rb
@@ -1,0 +1,11 @@
+module Fictium
+  module RSpec
+    module Proxies
+      class Action < Base
+        def additional_arguments
+          { fictium_action: true }
+        end
+      end
+    end
+  end
+end

--- a/lib/fictium/rspec/proxies/base.rb
+++ b/lib/fictium/rspec/proxies/base.rb
@@ -1,0 +1,25 @@
+module Fictium
+  module RSpec
+    module Proxies
+      class Base
+        attr_reader :context, :args, :first_arg, :kwargs
+        def initialize(context, *args, **kwargs)
+          @context = context
+          @first_arg = args.shift
+          @args = args
+          @kwargs = kwargs
+        end
+
+        def evaluate(block, extra_args, extra_kwargs)
+          list_arguments = first_arg + args + extra_args
+          key_arguments = extra_kwargs.merge(kwargs).merge(additional_arguments)
+          context.send(evaluate_method_name, *list_arguments, **key_arguments, &block)
+        end
+
+        def evaluate_method_name
+          :describe
+        end
+      end
+    end
+  end
+end

--- a/lib/fictium/rspec/proxies/example.rb
+++ b/lib/fictium/rspec/proxies/example.rb
@@ -1,0 +1,15 @@
+module Fictium
+  module RSpec
+    module Proxies
+      class Example < Base
+        def additional_arguments
+          { fictium_example: true }
+        end
+
+        def evaluate_method_name
+          :context
+        end
+      end
+    end
+  end
+end

--- a/lib/fictium/rspec/proxy_handler.rb
+++ b/lib/fictium/rspec/proxy_handler.rb
@@ -1,0 +1,11 @@
+module Fictium
+  module RSpec
+    module ProxyHandler
+      def describe(subject, *args, **kwargs, &block)
+        return subject.evaluate(block, args, kwargs) if subject.is_a?(Proxies::Base)
+
+        super
+      end
+    end
+  end
+end

--- a/lib/fictium/rspec/resources.rb
+++ b/lib/fictium/rspec/resources.rb
@@ -1,0 +1,38 @@
+module Fictium
+  module RSpec
+    module Resources
+      extend ActiveSupport::Concern
+
+      included do
+        metadata[:fictium_resource] = Fictium::RSpec.document.create_resource
+        metadata[:fictium_resource].name_attributes(metadata[:described_class].name)
+      end
+
+      class_methods do
+        def action(*args, **kwargs)
+          Fictium::RSpec::Proxies::Action.new(self, args, kwargs)
+        end
+
+        def base_path(path)
+          metadata[:fictium_resource].base_path = path
+        end
+
+        def resource_name(name)
+          metadata[:fictium_resource].name = name
+        end
+
+        def resource_summary(summary)
+          metadata[:fictium_resource].summary = summary
+        end
+
+        def resource_description(description)
+          metadata[:fictium_resource].description = description
+        end
+
+        def resource_tags(*tags)
+          metadata[:fictium_resource].tags += tags
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/books_controller_spec.rb
+++ b/spec/controllers/books_controller_spec.rb
@@ -1,21 +1,36 @@
 describe BooksController do
-  describe 'GET #index' do
+  # While automatically inferred, they can be also manually specified:
+  base_path '/tags/:tag_id/books'
+  resource_name 'book'
+  resource_summary 'Lists all books for a specific tag.'
+  resource_description <<~HEREDOC
+    This will fail if the tag does not exists.
+    The results are not paginated.
+  HEREDOC
+  resource_tags 'tags', 'list'
+
+  describe action 'GET #index' do
     subject(:make_request) { get :index, params: params }
+
+    # This is also auto detected, but can be manually changed
+    path ''
 
     let(:params) { { topic_id: topic_id } }
     let(:topic_id) { 1 }
 
-    context 'when a valid topic is given' do
+    describe example 'when a valid topic is given' do
       before do
         make_request
       end
+
+      default_example
 
       it 'responds with ok status' do
         expect(response).to have_http_status(:ok)
       end
     end
 
-    context 'when an invalid topic is given' do
+    describe example 'when an invalid topic is given' do
       let(:topic_id) { -1 }
 
       include_examples 'not found examples'

--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -1,11 +1,15 @@
 describe TopicsController do
-  describe 'GET #index' do
+  describe action 'GET #index' do
     subject(:make_request) { get :index }
 
-    context 'when a valid request is processed' do
+    describe example 'when a valid request is processed' do
+      default_example
+
       before do
         make_request
       end
+
+      default_example
 
       it 'responds with ok status' do
         expect(response).to have_http_status(:ok)
@@ -13,12 +17,14 @@ describe TopicsController do
     end
   end
 
-  describe 'GET #show' do
+  describe action 'GET #show' do
     subject(:make_request) { get :show, params: { id: topic_id } }
 
     let(:topic_id) { 1 }
 
-    context 'when a valid topic is given' do
+    describe example 'when a valid topic is given' do
+      default_example
+
       before do
         make_request
       end
@@ -28,20 +34,22 @@ describe TopicsController do
       end
     end
 
-    context 'when an invalid topic is given' do
+    describe example 'when an invalid topic is given' do
       let(:topic_id) { -1 }
 
       include_examples 'not found examples'
     end
   end
 
-  describe 'POST #create' do
+  describe action 'POST #create' do
     subject(:make_request) { post :create, params: params }
 
     let(:params) { {} }
 
-    context 'when a logged in user passes valid parameters' do
+    describe example 'when a logged in user passes valid parameters' do
       include_context 'with account login'
+
+      default_example
 
       let(:params) { { topic: { name: 'New Topic' } } }
 
@@ -54,7 +62,7 @@ describe TopicsController do
       end
     end
 
-    context 'when a logged in user passes invalid parameters' do
+    describe example 'when a logged in user passes invalid parameters' do
       let(:params) { {} }
 
       include_examples 'unprocessable entity examples'
@@ -63,13 +71,15 @@ describe TopicsController do
     include_examples 'unauthorized when not logged in'
   end
 
-  describe 'PATCH #update' do
+  describe action 'PATCH #update' do
     subject(:make_request) { patch :update, params: params }
 
     let(:params) { { id: 1, topic: { name: 'New name' } } }
 
-    context 'when a logged in user passes valid parameters' do
+    describe example 'when a logged in user passes valid parameters' do
       include_context 'with account login'
+
+      default_example
 
       before do
         make_request
@@ -80,7 +90,7 @@ describe TopicsController do
       end
     end
 
-    context 'when a logged in user passes invalid parameters' do
+    describe example 'when a logged in user passes invalid parameters' do
       include_context 'with account login'
 
       let(:params) { { id: 1 } }
@@ -88,7 +98,7 @@ describe TopicsController do
       include_examples 'unprocessable entity examples'
     end
 
-    context 'when the topic does not exists' do
+    describe example 'when the topic does not exists' do
       include_context 'with account login'
 
       let(:params) { { id: -1 } }
@@ -99,13 +109,15 @@ describe TopicsController do
     include_examples 'unauthorized when not logged in'
   end
 
-  describe 'DELETE #destroy' do
+  describe action 'DELETE #destroy' do
     subject(:make_request) { delete :destroy, params: params }
 
     let(:params) { { id: 1 } }
 
-    context 'when a logged in user gives a valid topic' do
+    describe example 'when a logged in user gives a valid topic' do
       include_context 'with account login'
+
+      default_example
 
       before do
         make_request
@@ -116,7 +128,7 @@ describe TopicsController do
       end
     end
 
-    context 'when the topic does not exists' do
+    describe example 'when the topic does not exists' do
       include_context 'with account login'
 
       let(:params) { { id: -1 } }

--- a/spec/poros/fictium/example_spec.rb
+++ b/spec/poros/fictium/example_spec.rb
@@ -6,7 +6,7 @@ describe Fictium::Example do
   describe '.new' do
     subject(:new_instance) { described_class.new(action) }
 
-    it 'contains  the action as a member' do
+    it 'contains the action as a member' do
       expect(new_instance.action).to eq action
     end
   end

--- a/spec/poros/fictium/example_spec.rb
+++ b/spec/poros/fictium/example_spec.rb
@@ -1,13 +1,21 @@
 describe Fictium::Example do
+  let(:action) { Fictium::Action.new(resource) }
+  let(:resource) { Fictium::Resource.new(document) }
+  let(:document) { Fictium::Document.new }
+
   describe '.new' do
     subject(:new_instance) { described_class.new(action) }
 
-    let(:action) { Fictium::Action.new(resource) }
-    let(:resource) { Fictium::Resource.new(document) }
-    let(:document) { Fictium::Document.new }
-
     it 'contains  the action as a member' do
       expect(new_instance.action).to eq action
+    end
+  end
+
+  describe '#default?' do
+    subject(:example) { described_class.new(action) }
+
+    it 'responds the same as de default value' do
+      expect(example.default?).to be example.default
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,9 @@ SimpleCov.start
 # Load default config (fictium included!)
 Bundler.require(:default)
 
+# Fictium's official RSpec integration
+require 'fictium/rspec'
+
 RSpec.configure do |config|
   config.include ActionDispatch::TestProcess
 

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,5 +1,5 @@
 shared_examples 'unauthorized when not logged in' do
-  context 'when no account is signed in' do
+  describe example 'when no account is signed in' do
     before do
       make_request
     end


### PR DESCRIPTION
## Summary

This PR adds the RSpec DSL used by the gem to auto generate documentation.

It requires some minor adjustments, but it allows you to generate quick documentation based on . your RSpec files, without touching most of it.