### PR TITLE
[FICTIUM-006] Add OpenAPI 3.0.0 specification importer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     fictium (0.1.0)
       activesupport (>= 5.3, < 6.2)
-      json-schema (~> 2.8.1)
+      json-schema (~> 2.8)
       verbs (~> 2.1.4)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     fictium (0.1.0)
       activesupport (>= 5.3, < 6.2)
+      json-schema (~> 2.8.1)
       verbs (~> 2.1.4)
 
 GEM
@@ -63,6 +64,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.1, >= 2.1.8)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
     brakeman (4.6.1)
     builder (3.2.3)
@@ -80,6 +83,8 @@ GEM
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.3)
     json (2.2.0)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -98,6 +103,7 @@ GEM
     parallel (1.18.0)
     parser (2.6.5.0)
       ast (~> 2.4.0)
+    public_suffix (4.0.1)
     rack (2.0.7)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Fictium is closely tied to RSpec and Rails, but it's developed in a way to suppo
 
 The primary goal is for generating OpenAPI Documentation, but, just like with RSpec, future versions may provide other output types.
 
+[Check out the wiki too!](./wiki)
+
+
 ### Common terminology of this gem
 
 Because this GEM is used to represent REST APIs, this gem, provides some common objects, which are used as a documentation naming scheme. They are independant from the actual documentation format, so each exporter should transform this abstract representation into the actual document representation.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Fictium
 
+[![Build Status](https://travis-ci.org/Wolox/fictium.svg?branch=master)](https://travis-ci.org/Wolox/fictium) [![Maintainability](https://api.codeclimate.com/v1/badges/52afbf838f92fe260b6e/maintainability)](https://codeclimate.com/github/Wolox/fictium/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/52afbf838f92fe260b6e/test_coverage)](https://codeclimate.com/github/Wolox/fictium/test_coverage)
+
 This gem is a documentation helper. The goal of this gem is, by adding small modifications into your existing tests,
 you can then transform it into easy REST documentation.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ end
 The idea, is that your controller has actions, and each actions has examples.
 You can, for now, check `spec/controllers` at this repository to
 
-TODO: Go deeper to explain default overrides
+You can deeply customize your endpoints using RSpec.
+Check out details [here](./wiki/RSpec-definitions).
 
 ## Development
 
@@ -91,14 +92,11 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/[USERN
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
 
+This gem is developed by (Wolox)[https://wolox.com.ar].
 
-## About
-
-This project was developed by [Ramiro Rojo](https://github.com/holywyvern).
 Maintainers: [Ramiro Rojo](https://github.com/holywyvern)
 Contributors: None (for now...)
 ![Wolox](https://raw.githubusercontent.com/Wolox/press-kit/master/logos/logo_banner.png)
-
 
 ## Code of Conduct
 

--- a/fictium.gemspec
+++ b/fictium.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
                               Fictium::RAILS_MAX_VERSION
 
   spec.add_runtime_dependency 'verbs', '~> 2.1.4'
+  spec.add_runtime_dependency 'json-schema', '~> 2.8.1'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
 

--- a/fictium.gemspec
+++ b/fictium.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
 
   spec.add_runtime_dependency 'json-schema', '~> 2.8.1'
   spec.add_runtime_dependency 'verbs', '~> 2.1.4'
-  spec.add_runtime_dependency 'json-schema', '~> 2.8.1'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
 

--- a/fictium.gemspec
+++ b/fictium.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
 
   spec.add_runtime_dependency 'json-schema', '~> 2.8.1'
   spec.add_runtime_dependency 'verbs', '~> 2.1.4'
+  spec.add_runtime_dependency 'json-schema', '~> 2.8.1'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
 

--- a/fictium.gemspec
+++ b/fictium.gemspec
@@ -33,8 +33,8 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
                               Fictium::RAILS_MIN_VERSION,
                               Fictium::RAILS_MAX_VERSION
 
-  spec.add_runtime_dependency 'verbs', '~> 2.1.4'
   spec.add_runtime_dependency 'json-schema', '~> 2.8.1'
+  spec.add_runtime_dependency 'verbs', '~> 2.1.4'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
 

--- a/fictium.gemspec
+++ b/fictium.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
                               Fictium::RAILS_MIN_VERSION,
                               Fictium::RAILS_MAX_VERSION
 
-  spec.add_runtime_dependency 'json-schema', '~> 2.8.1'
+  spec.add_runtime_dependency 'json-schema', '~> 2.8'
   spec.add_runtime_dependency 'verbs', '~> 2.1.4'
 
   spec.add_development_dependency 'bundler', '~> 2.0'

--- a/lib/fictium.rb
+++ b/lib/fictium.rb
@@ -1,6 +1,9 @@
 # Use core extensions on this gem
 require 'active_support'
 
+# JSON Schema validators
+require 'json-schema'
+
 # Core functionalities
 require_relative 'fictium/version'
 

--- a/lib/fictium/configurations/configuration.rb
+++ b/lib/fictium/configurations/configuration.rb
@@ -6,7 +6,7 @@ module Fictium
     attr_reader :info
     attr_accessor :exporters, :summary_format, :default_action_descriptors,
                   :unknown_action_descriptor, :default_subject, :fixture_path,
-                  :export_path, :default_content_type, :pretty_print
+                  :export_path, :default_response_content_type, :pretty_print
 
     def initialize
       @info = Fictium::Configuration::Info.new
@@ -33,7 +33,7 @@ module Fictium
     def setup_strings
       @default_subject = 'This endpoint'
       @export_path = 'doc'
-      @default_content_type = 'text/plain'
+      @default_response_content_type = 'text/plain'
     end
 
     def default_summary_format(resources)

--- a/lib/fictium/configurations/configuration.rb
+++ b/lib/fictium/configurations/configuration.rb
@@ -6,7 +6,7 @@ module Fictium
       accept content-type authorization http_accept content_type
       request_method server_name server_port query_string
       http_cookie path_info x-frame-options x-xss-protection x-content-type-options
-      x-download-options x-permitted-cross-domain-policies refrrer-policy
+      x-download-options x-permitted-cross-domain-policies referrer-policy
       https script_name http_host remote_addr http_user_agent
       http_authorization content_length raw_post_data
     ].freeze

--- a/lib/fictium/configurations/configuration.rb
+++ b/lib/fictium/configurations/configuration.rb
@@ -1,12 +1,13 @@
 module Fictium
   class Configuration
     VOWEL = /[aeiou]/i.freeze
-    DEFAULT_IGNORED_HEADERS_GROUPS = %w[rack. action_dispatch.].freeze
+    DEFAULT_IGNORED_HEADERS_GROUPS = %w[rack. action_dispatch. action_controller.].freeze
     DEFAULT_IGNORED_HEADERS = %w[
       accept content-type authorization http_accept content_type
       request_method server_name server_port query_string
       http_cookie path_info x-frame-options x-xss-protection x-content-type-options
       x-download-options x-permitted-cross-domain-policies refrrer-policy
+      https script_name http_host remote_addr http_user_agent
     ].freeze
     private_constant :VOWEL
 

--- a/lib/fictium/configurations/configuration.rb
+++ b/lib/fictium/configurations/configuration.rb
@@ -3,14 +3,23 @@ module Fictium
     VOWEL = /[aeiou]/i.freeze
     private_constant :VOWEL
 
+    attr_reader :info
     attr_accessor :exporters, :summary_format, :default_action_descriptors,
-                  :unknown_action_descriptor, :default_subject
+                  :unknown_action_descriptor, :default_subject, :fixture_path,
+                  :export_path
 
     def initialize
-      # TODO: Add default exporter in exporter list
-      @exporters = []
+      @info = Fictium::Configuration::Info.new
+      @exporters = [Fictium::OpenApi::V3Exporter.new]
 
       @summary_format = method(:default_summary_format)
+      setup_descriptors
+      setup_strings
+    end
+
+    private
+
+    def setup_descriptors
       @default_action_descriptors = {
         default_summary_for_index: method(:default_summary_for_index),
         default_summary_for_show: method(:default_summary_for_show),
@@ -18,10 +27,12 @@ module Fictium
         default_summary_for_destroy: method(:default_summary_for_destroy)
       }
       @unknown_action_descriptor = method(:default_unknown_action_descriptor)
-      @default_subject = 'This endpoint'
     end
 
-    private
+    def setup_strings
+      @default_subject = 'This endpoint'
+      @export_path = 'doc'
+    end
 
     def default_summary_format(resources)
       "Handles API #{resources}."

--- a/lib/fictium/configurations/configuration.rb
+++ b/lib/fictium/configurations/configuration.rb
@@ -5,7 +5,8 @@ module Fictium
     DEFAULT_IGNORED_HEADERS = %w[
       accept content-type authorization http_accept content_type
       request_method server_name server_port query_string
-      http_cookie path_info
+      http_cookie path_info x-frame-options x-xss-protection x-content-type-options
+      x-download-options x-permitted-cross-domain-policies refrrer-policy
     ].freeze
     private_constant :VOWEL
 

--- a/lib/fictium/configurations/configuration.rb
+++ b/lib/fictium/configurations/configuration.rb
@@ -1,12 +1,19 @@
 module Fictium
   class Configuration
     VOWEL = /[aeiou]/i.freeze
+    DEFAULT_IGNORED_HEADERS_GROUPS = %w[rack. action_dispatch.].freeze
+    DEFAULT_IGNORED_HEADERS = %w[
+      accept content-type authorization http_accept content_type
+      request_method server_name server_port query_string
+      http_cookie path_info
+    ].freeze
     private_constant :VOWEL
 
     attr_reader :info
     attr_accessor :exporters, :summary_format, :default_action_descriptors,
                   :unknown_action_descriptor, :default_subject, :fixture_path,
-                  :export_path, :default_response_content_type, :pretty_print
+                  :export_path, :default_response_content_type, :pretty_print,
+                  :ignored_header_values, :ignored_header_groups
 
     def initialize
       @info = Fictium::Configuration::Info.new
@@ -16,6 +23,8 @@ module Fictium
       @pretty_print = true
       setup_descriptors
       setup_strings
+      @ignored_header_values = DEFAULT_IGNORED_HEADERS.dup
+      @ignored_header_groups = DEFAULT_IGNORED_HEADERS_GROUPS.dup
     end
 
     private

--- a/lib/fictium/configurations/configuration.rb
+++ b/lib/fictium/configurations/configuration.rb
@@ -6,13 +6,14 @@ module Fictium
     attr_reader :info
     attr_accessor :exporters, :summary_format, :default_action_descriptors,
                   :unknown_action_descriptor, :default_subject, :fixture_path,
-                  :export_path
+                  :export_path, :default_content_type, :pretty_print
 
     def initialize
       @info = Fictium::Configuration::Info.new
       @exporters = [Fictium::OpenApi::V3Exporter.new]
 
       @summary_format = method(:default_summary_format)
+      @pretty_print = true
       setup_descriptors
       setup_strings
     end
@@ -32,6 +33,7 @@ module Fictium
     def setup_strings
       @default_subject = 'This endpoint'
       @export_path = 'doc'
+      @default_content_type = 'text/plain'
     end
 
     def default_summary_format(resources)

--- a/lib/fictium/configurations/configuration.rb
+++ b/lib/fictium/configurations/configuration.rb
@@ -8,6 +8,7 @@ module Fictium
       http_cookie path_info x-frame-options x-xss-protection x-content-type-options
       x-download-options x-permitted-cross-domain-policies refrrer-policy
       https script_name http_host remote_addr http_user_agent
+      http_authorization content_length raw_post_data
     ].freeze
     private_constant :VOWEL
 

--- a/lib/fictium/configurations/info.rb
+++ b/lib/fictium/configurations/info.rb
@@ -1,0 +1,12 @@
+module Fictium
+  class Configuration
+    class Info
+      attr_accessor :title, :description, :terms_of_service, :contract, :license, :version
+
+      def initialize
+        self.title = 'TODO: Change me at Fictium.configuration.api'
+        self.version = '0.1.0'
+      end
+    end
+  end
+end

--- a/lib/fictium/evaluators/parameter_evaluator.rb
+++ b/lib/fictium/evaluators/parameter_evaluator.rb
@@ -39,8 +39,15 @@ module Fictium
         required: required,
         deprecated: deprecated,
         allowEmptyValue: allow_empty,
-        schema: kwargs[:schema] && schema_evaluator.format(**kwargs[:schema])
+        schema: format_schema(kwargs)
       }
+    end
+
+    def format_schema(args)
+      return unless args[:schema].present?
+
+      schema_evaluator.format(ref: args[:schema][:ref]) if args[:schema][:ref].present?
+      schema_evaluator.format(args[:schema])
     end
 
     def schema_evaluator

--- a/lib/fictium/evaluators/parameter_evaluator.rb
+++ b/lib/fictium/evaluators/parameter_evaluator.rb
@@ -15,10 +15,8 @@ module Fictium
       @params
     end
 
-    def method_missing(name, *args)
-      return self[name] = yield if respond_to_missing?(name) && block_given?
-
-      super
+    def method_missing(name, *_, **kwargs) # rubocop:disable Style/MethodMissingSuper
+      self[name] = validate_keys(**kwargs) if respond_to_missing?(name)
     end
 
     def [](name)
@@ -29,8 +27,24 @@ module Fictium
       @params[name] = value
     end
 
+    private
+
     def respond_to_missing?(_method_name, _include_private = false)
       true
+    end
+
+    def validate_keys(required: false, deprecated: false, allow_empty: false, **kwargs)
+      {
+        description: kwargs[:description],
+        required: required,
+        deprecated: deprecated,
+        allowEmptyValue: allow_empty,
+        schema: kwargs[:schema] && schema_evaluator.format(**kwargs[:schema])
+      }
+    end
+
+    def schema_evaluator
+      @schema_evaluator ||= Fictium::SchemaEvaluator.new
     end
   end
 end

--- a/lib/fictium/evaluators/parameter_evaluator.rb
+++ b/lib/fictium/evaluators/parameter_evaluator.rb
@@ -38,7 +38,7 @@ module Fictium
         description: kwargs[:description],
         required: required,
         deprecated: deprecated,
-        allowEmptyValue: allow_empty,
+        allow_empty: allow_empty,
         schema: format_schema(kwargs)
       }
     end

--- a/lib/fictium/evaluators/schema_evaluator.rb
+++ b/lib/fictium/evaluators/schema_evaluator.rb
@@ -1,15 +1,7 @@
 module Fictium
   class SchemaEvaluator
-    def format(obj = nil)
-      raise error_message if obj.blank?
-
+    def format(obj)
       obj[:ref].present? ? { '$ref': obj[:ref] } : obj
-    end
-
-    private
-
-    def error_message
-      'Object schemeas needs a hash or a reference path'
     end
   end
 end

--- a/lib/fictium/evaluators/schema_evaluator.rb
+++ b/lib/fictium/evaluators/schema_evaluator.rb
@@ -1,9 +1,9 @@
 module Fictium
   class SchemaEvaluator
-    def format(obj = nil, ref: nil)
-      raise error_message if obj.blank? && ref.blank?
+    def format(obj = nil)
+      raise error_message if obj.blank?
 
-      ref.present? ? { '$ref': ref } : obj
+      obj[:ref].present? ? { '$ref': obj[:ref] } : obj
     end
 
     private

--- a/lib/fictium/evaluators/schema_evaluator.rb
+++ b/lib/fictium/evaluators/schema_evaluator.rb
@@ -1,0 +1,15 @@
+module Fictium
+  class SchemaEvaluator
+    def format(obj = nil, ref: nil)
+      raise error_message if obj.blank? && ref.blank?
+
+      ref.present? ? { '$ref': ref } : obj
+    end
+
+    private
+
+    def error_message
+      'Object schemeas needs a hash or a reference path'
+    end
+  end
+end

--- a/lib/fictium/exporters/open_api/schemas/3.0.0.json
+++ b/lib/fictium/exporters/open_api/schemas/3.0.0.json
@@ -1,0 +1,1654 @@
+{
+  "id": "https://spec.openapis.org/oas/3.0/schema/2019-04-02",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Validation schema for OpenAPI Specification 3.0.X.",
+  "type": "object",
+  "required": [
+    "openapi",
+    "info",
+    "paths"
+  ],
+  "properties": {
+    "openapi": {
+      "type": "string",
+      "pattern": "^3\\.0\\.\\d(-.+)?$"
+    },
+    "info": {
+      "$ref": "#/definitions/Info"
+    },
+    "externalDocs": {
+      "$ref": "#/definitions/ExternalDocumentation"
+    },
+    "servers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Server"
+      }
+    },
+    "security": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/SecurityRequirement"
+      }
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Tag"
+      },
+      "uniqueItems": true
+    },
+    "paths": {
+      "$ref": "#/definitions/Paths"
+    },
+    "components": {
+      "$ref": "#/definitions/Components"
+    }
+  },
+  "patternProperties": {
+    "^x-": {
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Reference": {
+      "type": "object",
+      "required": [
+        "$ref"
+      ],
+      "patternProperties": {
+        "^\\$ref$": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      }
+    },
+    "Info": {
+      "type": "object",
+      "required": [
+        "title",
+        "version"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "termsOfService": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "contact": {
+          "$ref": "#/definitions/Contact"
+        },
+        "license": {
+          "$ref": "#/definitions/License"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "Contact": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "License": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "Server": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "variables": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ServerVariable"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "ServerVariable": {
+      "type": "object",
+      "required": [
+        "default"
+      ],
+      "properties": {
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "Components": {
+      "type": "object",
+      "properties": {
+        "schemas": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Schema"
+                },
+                {
+                  "$ref": "#/definitions/Reference"
+                }
+              ]
+            }
+          }
+        },
+        "responses": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Response"
+                }
+              ]
+            }
+          }
+        },
+        "parameters": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Parameter"
+                }
+              ]
+            }
+          }
+        },
+        "examples": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Example"
+                }
+              ]
+            }
+          }
+        },
+        "requestBodies": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/RequestBody"
+                }
+              ]
+            }
+          }
+        },
+        "headers": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Header"
+                }
+              ]
+            }
+          }
+        },
+        "securitySchemes": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/SecurityScheme"
+                }
+              ]
+            }
+          }
+        },
+        "links": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Link"
+                }
+              ]
+            }
+          }
+        },
+        "callbacks": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Callback"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "Schema": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "multipleOf": {
+          "type": "number",
+          "minimum": 0,
+          "exclusiveMinimum": true
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "exclusiveMaximum": {
+          "type": "boolean",
+          "default": false
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "exclusiveMinimum": {
+          "type": "boolean",
+          "default": false
+        },
+        "maxLength": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minLength": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        },
+        "pattern": {
+          "type": "string",
+          "format": "regex"
+        },
+        "maxItems": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minItems": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        },
+        "uniqueItems": {
+          "type": "boolean",
+          "default": false
+        },
+        "maxProperties": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minProperties": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        },
+        "required": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "enum": {
+          "type": "array",
+          "items": {
+          },
+          "minItems": 1,
+          "uniqueItems": false
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "array",
+            "boolean",
+            "integer",
+            "number",
+            "object",
+            "string"
+          ]
+        },
+        "not": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "allOf": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Schema"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "oneOf": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Schema"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "anyOf": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Schema"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "items": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Schema"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "default": true
+        },
+        "description": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "default": {
+        },
+        "nullable": {
+          "type": "boolean",
+          "default": false
+        },
+        "discriminator": {
+          "$ref": "#/definitions/Discriminator"
+        },
+        "readOnly": {
+          "type": "boolean",
+          "default": false
+        },
+        "writeOnly": {
+          "type": "boolean",
+          "default": false
+        },
+        "example": {
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/ExternalDocumentation"
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "xml": {
+          "$ref": "#/definitions/XML"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "Discriminator": {
+      "type": "object",
+      "required": [
+        "propertyName"
+      ],
+      "properties": {
+        "propertyName": {
+          "type": "string"
+        },
+        "mapping": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "XML": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string",
+          "format": "uri"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "attribute": {
+          "type": "boolean",
+          "default": false
+        },
+        "wrapped": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "Response": {
+      "type": "object",
+      "required": [
+        "description"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Header"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "content": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          }
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Link"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "MediaType": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "example": {
+        },
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Example"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "encoding": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Encoding"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExampleXORExamples"
+        }
+      ]
+    },
+    "Example": {
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "value": {
+        },
+        "externalValue": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "Header": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean",
+          "default": false
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "allowEmptyValue": {
+          "type": "boolean",
+          "default": false
+        },
+        "style": {
+          "type": "string",
+          "enum": [
+            "simple"
+          ],
+          "default": "simple"
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "type": "boolean",
+          "default": false
+        },
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "content": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          },
+          "minProperties": 1,
+          "maxProperties": 1
+        },
+        "example": {
+        },
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Example"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExampleXORExamples"
+        },
+        {
+          "$ref": "#/definitions/SchemaXORContent"
+        }
+      ]
+    },
+    "Paths": {
+      "type": "object",
+      "patternProperties": {
+        "^\\/": {
+          "$ref": "#/definitions/PathItem"
+        },
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "PathItem": {
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Server"
+          }
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Parameter"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          },
+          "uniqueItems": true
+        }
+      },
+      "patternProperties": {
+        "^(get|put|post|delete|options|head|patch|trace)$": {
+          "$ref": "#/definitions/Operation"
+        },
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "Operation": {
+      "type": "object",
+      "required": [
+        "responses"
+      ],
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/ExternalDocumentation"
+        },
+        "operationId": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Parameter"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          },
+          "uniqueItems": true
+        },
+        "requestBody": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RequestBody"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "responses": {
+          "$ref": "#/definitions/Responses"
+        },
+        "callbacks": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Callback"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "security": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SecurityRequirement"
+          }
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Server"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "Responses": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Response"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        }
+      },
+      "patternProperties": {
+        "^[1-5](?:\\d{2}|XX)$": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Response"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "^x-": {
+        }
+      },
+      "minProperties": 1,
+      "additionalProperties": false
+    },
+    "SecurityRequirement": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "Tag": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/ExternalDocumentation"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExternalDocumentation": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExampleXORExamples": {
+      "description": "Example and examples are mutually exclusive",
+      "not": {
+        "required": [
+          "example",
+          "examples"
+        ]
+      }
+    },
+    "SchemaXORContent": {
+      "description": "Schema and content are mutually exclusive, at least one is required",
+      "not": {
+        "required": [
+          "schema",
+          "content"
+        ]
+      },
+      "oneOf": [
+        {
+          "required": [
+            "schema"
+          ]
+        },
+        {
+          "required": [
+            "content"
+          ],
+          "description": "Some properties are not allowed if content is present",
+          "allOf": [
+            {
+              "not": {
+                "required": [
+                  "style"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "explode"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "allowReserved"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "example"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "examples"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "Parameter": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean",
+          "default": false
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "allowEmptyValue": {
+          "type": "boolean",
+          "default": false
+        },
+        "style": {
+          "type": "string"
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "type": "boolean",
+          "default": false
+        },
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "content": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          },
+          "minProperties": 1,
+          "maxProperties": 1
+        },
+        "example": {
+        },
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Example"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "in"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExampleXORExamples"
+        },
+        {
+          "$ref": "#/definitions/SchemaXORContent"
+        },
+        {
+          "$ref": "#/definitions/ParameterLocation"
+        }
+      ]
+    },
+    "ParameterLocation": {
+      "description": "Parameter location",
+      "oneOf": [
+        {
+          "description": "Parameter in path",
+          "required": [
+            "required"
+          ],
+          "properties": {
+            "in": {
+              "enum": [
+                "path"
+              ]
+            },
+            "style": {
+              "enum": [
+                "matrix",
+                "label",
+                "simple"
+              ],
+              "default": "simple"
+            },
+            "required": {
+              "enum": [
+                true
+              ]
+            }
+          }
+        },
+        {
+          "description": "Parameter in query",
+          "properties": {
+            "in": {
+              "enum": [
+                "query"
+              ]
+            },
+            "style": {
+              "enum": [
+                "form",
+                "spaceDelimited",
+                "pipeDelimited",
+                "deepObject"
+              ],
+              "default": "form"
+            }
+          }
+        },
+        {
+          "description": "Parameter in header",
+          "properties": {
+            "in": {
+              "enum": [
+                "header"
+              ]
+            },
+            "style": {
+              "enum": [
+                "simple"
+              ],
+              "default": "simple"
+            }
+          }
+        },
+        {
+          "description": "Parameter in cookie",
+          "properties": {
+            "in": {
+              "enum": [
+                "cookie"
+              ]
+            },
+            "style": {
+              "enum": [
+                "form"
+              ],
+              "default": "form"
+            }
+          }
+        }
+      ]
+    },
+    "RequestBody": {
+      "type": "object",
+      "required": [
+        "content"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "content": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          }
+        },
+        "required": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "SecurityScheme": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/APIKeySecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/HTTPSecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/OAuth2SecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/OpenIdConnectSecurityScheme"
+        }
+      ]
+    },
+    "APIKeySecurityScheme": {
+      "type": "object",
+      "required": [
+        "type",
+        "name",
+        "in"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "apiKey"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "type": "string",
+          "enum": [
+            "header",
+            "query",
+            "cookie"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "HTTPSecurityScheme": {
+      "type": "object",
+      "required": [
+        "scheme",
+        "type"
+      ],
+      "properties": {
+        "scheme": {
+          "type": "string"
+        },
+        "bearerFormat": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "http"
+          ]
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false,
+      "oneOf": [
+        {
+          "description": "Bearer",
+          "properties": {
+            "scheme": {
+              "enum": [
+                "bearer"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Non Bearer",
+          "not": {
+            "required": [
+              "bearerFormat"
+            ]
+          },
+          "properties": {
+            "scheme": {
+              "not": {
+                "enum": [
+                  "bearer"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "OAuth2SecurityScheme": {
+      "type": "object",
+      "required": [
+        "type",
+        "flows"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "oauth2"
+          ]
+        },
+        "flows": {
+          "$ref": "#/definitions/OAuthFlows"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "OpenIdConnectSecurityScheme": {
+      "type": "object",
+      "required": [
+        "type",
+        "openIdConnectUrl"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "openIdConnect"
+          ]
+        },
+        "openIdConnectUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "OAuthFlows": {
+      "type": "object",
+      "properties": {
+        "implicit": {
+          "$ref": "#/definitions/ImplicitOAuthFlow"
+        },
+        "password": {
+          "$ref": "#/definitions/PasswordOAuthFlow"
+        },
+        "clientCredentials": {
+          "$ref": "#/definitions/ClientCredentialsFlow"
+        },
+        "authorizationCode": {
+          "$ref": "#/definitions/AuthorizationCodeOAuthFlow"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "ImplicitOAuthFlow": {
+      "type": "object",
+      "required": [
+        "authorizationUrl",
+        "scopes"
+      ],
+      "properties": {
+        "authorizationUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "refreshUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "scopes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "PasswordOAuthFlow": {
+      "type": "object",
+      "required": [
+        "tokenUrl"
+      ],
+      "properties": {
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "refreshUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "scopes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "ClientCredentialsFlow": {
+      "type": "object",
+      "required": [
+        "tokenUrl"
+      ],
+      "properties": {
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "refreshUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "scopes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "AuthorizationCodeOAuthFlow": {
+      "type": "object",
+      "required": [
+        "authorizationUrl",
+        "tokenUrl"
+      ],
+      "properties": {
+        "authorizationUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "refreshUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "scopes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "Link": {
+      "type": "object",
+      "properties": {
+        "operationId": {
+          "type": "string"
+        },
+        "operationRef": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+          }
+        },
+        "requestBody": {
+        },
+        "description": {
+          "type": "string"
+        },
+        "server": {
+          "$ref": "#/definitions/Server"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false,
+      "not": {
+        "description": "Operation Id and Operation Ref are mutually exclusive",
+        "required": [
+          "operationId",
+          "operationRef"
+        ]
+      }
+    },
+    "Callback": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/PathItem"
+      },
+      "patternProperties": {
+        "^x-": {
+        }
+      }
+    },
+    "Encoding": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Header"
+          }
+        },
+        "style": {
+          "type": "string",
+          "enum": [
+            "form",
+            "spaceDelimited",
+            "pipeDelimited",
+            "deepObject"
+          ]
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/lib/fictium/exporters/open_api/v3_exporter.rb
+++ b/lib/fictium/exporters/open_api/v3_exporter.rb
@@ -1,3 +1,5 @@
+require_relative 'v3_exporter/content_formatter'
+require_relative 'v3_exporter/example_formatter'
 require_relative 'v3_exporter/path_formatter'
 require_relative 'v3_exporter/path_generator'
 

--- a/lib/fictium/exporters/open_api/v3_exporter.rb
+++ b/lib/fictium/exporters/open_api/v3_exporter.rb
@@ -16,7 +16,7 @@ module Fictium
                  .merge(info: create_info, paths: create_paths(document))
         validate!(result)
         FileUtils.mkdir_p(File.dirname(export_file))
-        File.write(export_file, result.to_json)
+        File.write(export_file, pretty_print? ? JSON.pretty_generate(result) : result.to_json)
       end
 
       private
@@ -65,6 +65,10 @@ module Fictium
 
       def schema
         @schema ||= JSON.parse(File.read(File.join(__dir__, 'schemas', '3.0.0.json')))
+      end
+
+      def pretty_print?
+        Fictium.configuration.pretty_print
       end
     end
   end

--- a/lib/fictium/exporters/open_api/v3_exporter.rb
+++ b/lib/fictium/exporters/open_api/v3_exporter.rb
@@ -1,0 +1,70 @@
+require_relative 'v3_exporter/path_generator'
+
+module Fictium
+  module OpenApi
+    class V3Exporter
+      DEFAULT_PROPERTIES = {
+        openapi: '3.0.0'
+      }.freeze
+      FIXTURE_TYPES = %w[servers security tags].freeze
+      INFO_OPTIONS = %w[title description terms_of_service contract license version].freeze
+
+      def export(document)
+        result = DEFAULT_PROPERTIES
+                 .merge(create_fixtures)
+                 .merge(info: create_info, paths: create_paths(document))
+        validate!(result)
+        FileUtils.mkdir_p(File.dirname(export_file))
+        File.write(export_file, result.to_json)
+      end
+
+      private
+
+      def export_file
+        @export_file ||=
+          File.join(Fictium.configuration.export_path, 'open_api', '3.0.0', 'swagger.json')
+      end
+
+      def create_fixtures
+        {}.tap do |fixtures|
+          FIXTURE_TYPES.each do |name|
+            result = load_fixtures(name)
+            fixtures[name.camelize(:lower)] = result if result.present?
+          end
+        end
+      end
+
+      def create_info
+        {}.tap do |info|
+          INFO_OPTIONS.each do |option|
+            value = Fictium.configuration.info.public_send(option)
+            info[option.camelize(:lower)] = value if value.present?
+          end
+        end
+      end
+
+      def create_paths(document)
+        V3Exporter::PathGenerator.new(document).generate
+      end
+
+      def load_fixtures(name)
+        fixture_file = File.join(fixture_path, "#{name}.json")
+        return unless File.exist?(fixture_file)
+
+        JSON.parse(File.read(fixture_file))
+      end
+
+      def fixture_path
+        Fictium.configuration.fixture_path
+      end
+
+      def validate!(result)
+        JSON::Validator.validate!(schema, result)
+      end
+
+      def schema
+        @schema ||= JSON.parse(File.read(File.join(__dir__, 'schemas', '3.0.0.json')))
+      end
+    end
+  end
+end

--- a/lib/fictium/exporters/open_api/v3_exporter.rb
+++ b/lib/fictium/exporters/open_api/v3_exporter.rb
@@ -1,5 +1,7 @@
 require_relative 'v3_exporter/content_formatter'
 require_relative 'v3_exporter/example_formatter'
+require_relative 'v3_exporter/param_formatter'
+
 require_relative 'v3_exporter/path_formatter'
 require_relative 'v3_exporter/path_generator'
 

--- a/lib/fictium/exporters/open_api/v3_exporter.rb
+++ b/lib/fictium/exporters/open_api/v3_exporter.rb
@@ -1,3 +1,4 @@
+require_relative 'v3_exporter/path_formatter'
 require_relative 'v3_exporter/path_generator'
 
 module Fictium

--- a/lib/fictium/exporters/open_api/v3_exporter/content_formatter.rb
+++ b/lib/fictium/exporters/open_api/v3_exporter/content_formatter.rb
@@ -1,0 +1,20 @@
+module Fictium
+  module OpenApi
+    class V3Exporter
+      class ContentFormatter
+        def format(http_object, default = nil)
+          type = (http_object.presence && http_object[:content_type].presence) || default
+          return if type.blank?
+
+          {}.tap do |content|
+            media_type = {
+              example: http_object[:body]
+            }
+            media_type[:schema] = http_object[:schema] if http_object[:schema].present?
+            content[type.to_sym] = media_type
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fictium/exporters/open_api/v3_exporter/example_formatter.rb
+++ b/lib/fictium/exporters/open_api/v3_exporter/example_formatter.rb
@@ -16,6 +16,8 @@ module Fictium
           { description: example.summary }.tap do |format|
             content = content_formatter.format(example.response, default_response_content_type)
             format[:content] = content if content.present?
+            headers = extract_headers(example)
+            format[:headers] = headers if headers.present?
           end
         end
 
@@ -23,8 +25,20 @@ module Fictium
           Fictium.configuration.default_response_content_type
         end
 
+        def extract_headers(example)
+          {}.tap do |headers|
+            example.headers.each do |name, value|
+              headers[name] = header_formatter.format(name, :header, value)
+            end
+          end
+        end
+
         def content_formatter
           @content_formatter ||= ContentFormatter.new
+        end
+
+        def header_formatter
+          @header_formatter ||= ParamFormatter.new(ignore_name: true, ignore_in: true)
         end
       end
     end

--- a/lib/fictium/exporters/open_api/v3_exporter/example_formatter.rb
+++ b/lib/fictium/exporters/open_api/v3_exporter/example_formatter.rb
@@ -1,0 +1,32 @@
+module Fictium
+  module OpenApi
+    class V3Exporter
+      class ExampleFormatter
+        def format_default(operation, responses, default_example)
+          responses[:default] = format(default_example)
+          return if default_example.request[:content_type].blank?
+
+          operation[:requestBody] = {
+            content: content_formatter.format(default_example.request)
+          }
+          operation[:requestBody][:required] = true if default_example.request[:required]
+        end
+
+        def format(example)
+          { description: example.summary }.tap do |format|
+            content = content_formatter.format(example.response, default_response_content_type)
+            format[:content] = content if content.present?
+          end
+        end
+
+        def default_response_content_type
+          Fictium.configuration.default_response_content_type
+        end
+
+        def content_formatter
+          @content_formatter ||= ContentFormatter.new
+        end
+      end
+    end
+  end
+end

--- a/lib/fictium/exporters/open_api/v3_exporter/param_formatter.rb
+++ b/lib/fictium/exporters/open_api/v3_exporter/param_formatter.rb
@@ -1,0 +1,40 @@
+module Fictium
+  module OpenApi
+    class V3Exporter
+      class ParamFormatter
+        def initialize(ignore_name: false, ignore_in: false)
+          @ignore_name = ignore_name
+          @ignore_in = ignore_in
+        end
+
+        def format(name, section, hash)
+          param = (hash || {})
+          description = param.slice(:description, :required, :deprecated, :schema)
+          description[:description] ||= ''
+          description[:name] = name unless ignore_name?
+          description[:in] = section unless ignore_in?
+          description[:allowEmptyValue] = param[:allow_empty] if param[:allow_empty].present?
+          description[:required] = true if section.to_s == 'path'
+          add_required_fields(description)
+          description
+        end
+
+        private
+
+        def ignore_in?
+          @ignore_in
+        end
+
+        def ignore_name?
+          @ignore_name
+        end
+
+        def add_required_fields(description)
+          return if description[:schema] || description[:content]
+
+          description[:schema] = {}
+        end
+      end
+    end
+  end
+end

--- a/lib/fictium/exporters/open_api/v3_exporter/param_formatter.rb
+++ b/lib/fictium/exporters/open_api/v3_exporter/param_formatter.rb
@@ -10,12 +10,9 @@ module Fictium
         def format(name, section, hash)
           param = (hash || {})
           description = param.slice(:description, :required, :deprecated, :schema)
-          description[:description] ||= ''
-          description[:name] = name unless ignore_name?
-          description[:in] = section unless ignore_in?
           description[:allowEmptyValue] = param[:allow_empty] if param[:allow_empty].present?
-          description[:required] = true if section.to_s == 'path'
           add_required_fields(description)
+          add_optional_fields(name, section, description)
           description
         end
 
@@ -30,9 +27,17 @@ module Fictium
         end
 
         def add_required_fields(description)
+          description[:description] ||= ''
+
           return if description[:schema] || description[:content]
 
           description[:schema] = {}
+        end
+
+        def add_optional_fields(name, section, description)
+          description[:name] = name unless ignore_name?
+          description[:in] = section unless ignore_in?
+          description[:required] = true if section.to_s == 'path'
         end
       end
     end

--- a/lib/fictium/exporters/open_api/v3_exporter/path_formatter.rb
+++ b/lib/fictium/exporters/open_api/v3_exporter/path_formatter.rb
@@ -33,46 +33,16 @@ module Fictium
             default_example = action.default_example
             break if default_example.blank?
 
-            format_default_example(operation, responses, default_example)
+            example_formatter.format_default(operation, responses, default_example)
             other_examples = action.examples.reject { |example| example == default_example }
             other_examples.each do |example|
-              responses[example.response[:status]] = format_example(example)
+              responses[example.response[:status]] = example_formatter.format(example)
             end
           end
         end
 
-        def format_default_example(operation, responses, default_example)
-          responses[:default] = format_example(default_example)
-          return if default_example.request[:content_type].blank?
-
-          operation[:requestBody] = {
-            content: format_content(default_example.request)
-          }
-          operation[:requestBody][:required] = true if default_example.request[:required]
-        end
-
-        def format_example(example)
-          { description: example.summary }.tap do |format|
-            content = format_content(example.response, default_response_content_type)
-            format[:content] = content if content.present?
-          end
-        end
-
-        def format_content(http_object, default = nil)
-          type = (http_object.presence && http_object[:content_type].presence) || default
-          return if type.blank?
-
-          {}.tap do |content|
-            media_type = {
-              example: http_object[:body]
-            }
-            media_type[:schema] = http_object[:schema] if http_object[:schema].present?
-            content[type.to_sym] = media_type
-          end
-        end
-
-        def default_response_content_type
-          Fictium.configuration.default_response_content_type
+        def example_formatter
+          @example_formatter ||= ExampleFormatter.new
         end
       end
     end

--- a/lib/fictium/exporters/open_api/v3_exporter/path_formatter.rb
+++ b/lib/fictium/exporters/open_api/v3_exporter/path_formatter.rb
@@ -3,6 +3,7 @@ module Fictium
     class V3Exporter
       class PathFormatter
         def add_path(paths, action)
+          paths[action.full_path]
         end
       end
     end

--- a/lib/fictium/exporters/open_api/v3_exporter/path_formatter.rb
+++ b/lib/fictium/exporters/open_api/v3_exporter/path_formatter.rb
@@ -54,10 +54,6 @@ module Fictium
         def param_formatter
           @param_formatter ||= ParamFormatter.new
         end
-
-        def header_formatter
-          @header_formatter ||= ParamFormatter.new(ignore_name: true, ignore_in: true)
-        end
       end
     end
   end

--- a/lib/fictium/exporters/open_api/v3_exporter/path_formatter.rb
+++ b/lib/fictium/exporters/open_api/v3_exporter/path_formatter.rb
@@ -24,8 +24,14 @@ module Fictium
           end
         end
 
-        def format_parameters(_action)
-          [] # TODO: Improve parameters
+        def format_parameters(action)
+          [].tap do |result|
+            action.params.each do |section, values|
+              values.each do |name, data|
+                result << param_formatter.format(name, section, data)
+              end
+            end
+          end
         end
 
         def format_responses(operation, action)
@@ -43,6 +49,14 @@ module Fictium
 
         def example_formatter
           @example_formatter ||= ExampleFormatter.new
+        end
+
+        def param_formatter
+          @param_formatter ||= ParamFormatter.new
+        end
+
+        def header_formatter
+          @header_formatter ||= ParamFormatter.new(ignore_name: true, ignore_in: true)
         end
       end
     end

--- a/lib/fictium/exporters/open_api/v3_exporter/path_formatter.rb
+++ b/lib/fictium/exporters/open_api/v3_exporter/path_formatter.rb
@@ -3,7 +3,57 @@ module Fictium
     class V3Exporter
       class PathFormatter
         def add_path(paths, action)
-          paths[action.full_path]
+          path_object = paths[action.full_path] || default_path_object
+          path_object[action.method.to_sym] = create_operation(action)
+          paths[action.full_path] = path_object
+        end
+
+        private
+
+        def default_path_object
+          { description: '' }
+        end
+
+        def create_operation(action)
+          {
+            tags: action.combined_tags,
+            description: action.summary,
+            parameters: format_parameters(action),
+            responses: format_responses(action),
+            deprecated: action.deprecated?
+          }
+        end
+
+        def format_parameters(_action)
+          [] # TODO: Improve parameters
+        end
+
+        def format_responses(action)
+          {}.tap do |responses|
+            default_response = action.default_example
+            break if default_response.blank?
+
+            responses[:default] = format_response(default_response)
+            action.examples.reject { |r| r == default_response }.each do |response|
+              responses[response.status_code] = format_response(response)
+            end
+          end
+        end
+
+        def format_response(response)
+          {
+            description: response.summary,
+            content: format_content(response)
+          }
+        end
+
+        def format_content(response)
+          type = response.content_type.presence || Fictium.configuration.default_content_type
+          {
+            type.to_sym => {
+              example: response.response_body
+            }
+          }
         end
       end
     end

--- a/lib/fictium/exporters/open_api/v3_exporter/path_formatter.rb
+++ b/lib/fictium/exporters/open_api/v3_exporter/path_formatter.rb
@@ -1,0 +1,10 @@
+module Fictium
+  module OpenApi
+    class V3Exporter
+      class PathFormatter
+        def add_path(paths, action)
+        end
+      end
+    end
+  end
+end

--- a/lib/fictium/exporters/open_api/v3_exporter/path_generator.rb
+++ b/lib/fictium/exporters/open_api/v3_exporter/path_generator.rb
@@ -9,7 +9,27 @@ module Fictium
         end
 
         def generate
-          {}
+          {}.tap do |paths|
+            document.resources.each do |resource|
+              generate_from_resource(paths, resource)
+            end
+          end
+        end
+
+        private
+
+        def generate_from_resource(paths, resource)
+          resource.actions.each do |action|
+            generate_from_action(paths, action)
+          end
+        end
+
+        def generate_from_action(paths, action)
+          path_formatter.add_path(paths, action)
+        end
+
+        def path_formatter
+          @path_formatter ||= PathFormatter.new
         end
       end
     end

--- a/lib/fictium/exporters/open_api/v3_exporter/path_generator.rb
+++ b/lib/fictium/exporters/open_api/v3_exporter/path_generator.rb
@@ -1,0 +1,17 @@
+module Fictium
+  module OpenApi
+    class V3Exporter
+      class PathGenerator
+        attr_reader :document
+
+        def initialize(document)
+          @document = document
+        end
+
+        def generate
+          {}
+        end
+      end
+    end
+  end
+end

--- a/lib/fictium/loader.rb
+++ b/lib/fictium/loader.rb
@@ -2,6 +2,7 @@ require_relative 'configurations/configuration'
 require_relative 'configurations/info'
 
 require_relative 'evaluators/parameter_evaluator'
+require_relative 'evaluators/schema_evaluator'
 
 require_relative 'poros/model'
 

--- a/lib/fictium/loader.rb
+++ b/lib/fictium/loader.rb
@@ -1,4 +1,5 @@
 require_relative 'configurations/configuration'
+require_relative 'configurations/info'
 
 require_relative 'evaluators/parameter_evaluator'
 
@@ -8,3 +9,6 @@ require_relative 'poros/action'
 require_relative 'poros/document'
 require_relative 'poros/example'
 require_relative 'poros/resource'
+
+# Require default (OpenApi v3) exporter
+require_relative 'exporters/open_api/v3_exporter'

--- a/lib/fictium/poros/action.rb
+++ b/lib/fictium/poros/action.rb
@@ -1,7 +1,7 @@
 module Fictium
   class Action < Fictium::Model
     ACTION_NAME = /#([A-Z_]+)/i.freeze
-    PATH_METHODS = /$(get|post|put|patch|delete)/i.freeze
+    PATH_METHODS = /^(get|post|put|patch|delete)/i.freeze
     DEFAULT_PATHS = {
       create: '',
       new: '/new',
@@ -10,14 +10,15 @@ module Fictium
       destroy: '/{id}'
     }.freeze
 
-    attr_reader :resource, :examples
-    attr_accessor :path, :summary, :description, :method, :tags
+    attr_reader :resource, :examples, :params
+    attr_accessor :path, :summary, :description, :method, :tags, :deprecated
 
     def initialize(resource)
       @resource = resource
       @params = ActiveSupport::HashWithIndifferentAccess.new
       @examples = []
       @tags = []
+      @deprecated = false
     end
 
     def full_path
@@ -46,6 +47,14 @@ module Fictium
 
     def combined_tags
       resource.tags + tags
+    end
+
+    def deprecated?
+      deprecated
+    end
+
+    def default_example
+      examples.find(&:default?).presence || examples.first
     end
 
     private

--- a/lib/fictium/poros/action.rb
+++ b/lib/fictium/poros/action.rb
@@ -11,12 +11,13 @@ module Fictium
     }.freeze
 
     attr_reader :resource, :examples
-    attr_accessor :path, :summary, :description, :method
+    attr_accessor :path, :summary, :description, :method, :tags
 
     def initialize(resource)
       @resource = resource
       @params = ActiveSupport::HashWithIndifferentAccess.new
       @examples = []
+      @tags = []
     end
 
     def full_path
@@ -41,6 +42,10 @@ module Fictium
       find_summary(name)
       find_path(name)
       find_method(description)
+    end
+
+    def combined_tags
+      resource.tags + tags
     end
 
     private

--- a/lib/fictium/poros/action.rb
+++ b/lib/fictium/poros/action.rb
@@ -1,15 +1,5 @@
 module Fictium
   class Action < Fictium::Model
-    ACTION_NAME = /#([A-Z_]+)/i.freeze
-    PATH_METHODS = /^(get|post|put|patch|delete)/i.freeze
-    DEFAULT_PATHS = {
-      create: '',
-      new: '/new',
-      show: '/{id}',
-      update: '/{id}',
-      destroy: '/{id}'
-    }.freeze
-
     attr_reader :resource, :examples, :params
     attr_accessor :path, :summary, :description, :method, :tags, :deprecated, :docs
 
@@ -38,12 +28,6 @@ module Fictium
       Fictium::Example.new(self).tap { |example| examples << example }
     end
 
-    def description_attributes(description)
-      name = find_action_name(description)&.downcase
-      find_summary(name)
-      find_path(name)
-    end
-
     def combined_tags
       resource.tags + tags
     end
@@ -54,33 +38,6 @@ module Fictium
 
     def default_example
       examples.find(&:default?).presence || examples.first
-    end
-
-    private
-
-    def find_summary(name)
-      return if name.blank?
-
-      key = :"default_summary_for_#{name}"
-      summary_method = descriptors[key] || Fictium.configuration.unknown_action_descriptor
-      one_argument = summary_method.arity == 1
-      self.summary = one_argument ? summary_method.call(self) : summary_method.call(self, name)
-    end
-
-    def descriptors
-      @descriptors ||= Fictium.configuration.default_action_descriptors || {}
-    end
-
-    def find_path(name)
-      return if name.blank?
-
-      key = name.to_sym
-      self.path = DEFAULT_PATHS[key].presence || "/{id}/#{name}"
-    end
-
-    def find_action_name(description)
-      match = description.match(ACTION_NAME)
-      match.presence && match[1]
     end
   end
 end

--- a/lib/fictium/poros/action.rb
+++ b/lib/fictium/poros/action.rb
@@ -42,7 +42,6 @@ module Fictium
       name = find_action_name(description)&.downcase
       find_summary(name)
       find_path(name)
-      find_method(description)
     end
 
     def combined_tags
@@ -70,11 +69,6 @@ module Fictium
 
     def descriptors
       @descriptors ||= Fictium.configuration.default_action_descriptors || {}
-    end
-
-    def find_method(description)
-      match = description.match(PATH_METHODS)
-      self.method = match.presence && match[1]&.downcase
     end
 
     def find_path(name)

--- a/lib/fictium/poros/action.rb
+++ b/lib/fictium/poros/action.rb
@@ -11,7 +11,7 @@ module Fictium
     }.freeze
 
     attr_reader :resource, :examples, :params
-    attr_accessor :path, :summary, :description, :method, :tags, :deprecated
+    attr_accessor :path, :summary, :description, :method, :tags, :deprecated, :docs
 
     def initialize(resource)
       @resource = resource

--- a/lib/fictium/poros/example.rb
+++ b/lib/fictium/poros/example.rb
@@ -7,28 +7,8 @@ module Fictium
       @action = action
     end
 
-    def process_http_response(response)
-      self.response = self.response || {
-        status: response.status,
-        body: response.body,
-        content_type: response.content_type
-      }
-      process_http_request(response.request)
-    end
-
     def default?
       default
-    end
-
-    private
-
-    def process_http_request(request)
-      self.request ||= {}
-      self.request.merge!(
-        content_type: request.content_type,
-        body: request.body.string
-      )
-      action.method = request.method.downcase.to_sym if action.method.blank?
     end
   end
 end

--- a/lib/fictium/poros/example.rb
+++ b/lib/fictium/poros/example.rb
@@ -1,20 +1,32 @@
 module Fictium
   class Example < Fictium::Model
     attr_reader :action
-    attr_accessor :summary, :description, :status_code, :response_body, :content_type, :default
+    attr_accessor :summary, :description, :response, :request, :default
 
     def initialize(action)
       @action = action
     end
 
     def process_http_response(response)
-      self.status_code = response.status
-      self.response_body = response.body
-      self.content_type = response.content_type
+      self.response = self.response || {
+        status: response.status,
+        body: response.body,
+        content_type: response.content_type
+      }
+      process_http_request(response.request)
     end
 
     def default?
       default
+    end
+
+    private
+
+    def process_http_request(request)
+      self.request = self.request || {
+        content_type: request.content_type,
+        body: request.body.string
+      }
     end
   end
 end

--- a/lib/fictium/poros/example.rb
+++ b/lib/fictium/poros/example.rb
@@ -23,10 +23,12 @@ module Fictium
     private
 
     def process_http_request(request)
-      self.request = self.request || {
+      self.request ||= {}
+      self.request.merge!(
         content_type: request.content_type,
         body: request.body.string
-      }
+      )
+      action.method = request.method.downcase.to_sym if action.method.blank?
     end
   end
 end

--- a/lib/fictium/poros/example.rb
+++ b/lib/fictium/poros/example.rb
@@ -1,10 +1,11 @@
 module Fictium
   class Example < Fictium::Model
     attr_reader :action
-    attr_accessor :summary, :description, :response, :request, :default
+    attr_accessor :summary, :description, :response, :request, :default, :headers
 
     def initialize(action)
       @action = action
+      @headers = ActiveSupport::HashWithIndifferentAccess.new
     end
 
     def default?

--- a/lib/fictium/poros/resource.rb
+++ b/lib/fictium/poros/resource.rb
@@ -1,7 +1,5 @@
 module Fictium
   class Resource < Fictium::Model
-    CONTROLLER_TERMINATION = /Controller$/.freeze
-
     attr_reader :document, :actions
     attr_accessor :name, :base_path, :summary, :description, :tags
 
@@ -13,15 +11,6 @@ module Fictium
 
     def create_action
       Fictium::Action.new(self).tap { |action| actions << action }
-    end
-
-    def name_attributes(controller_name)
-      resource_path = controller_name.sub(CONTROLLER_TERMINATION, '').underscore
-      self.base_path = "/#{resource_path}"
-      path_sections = resource_path.split('/')
-      plural = path_sections.last
-      self.name = plural.singularize.humanize(capitalize: false)
-      self.summary = Fictium.configuration.summary_format.call(plural)
     end
   end
 end

--- a/lib/fictium/rspec.rb
+++ b/lib/fictium/rspec.rb
@@ -7,6 +7,7 @@ require_relative 'rspec/proxy_handler'
 require_relative 'rspec/autocomplete/action'
 require_relative 'rspec/autocomplete/example'
 require_relative 'rspec/autocomplete/resource'
+require_relative 'rspec/autocomplete/params'
 
 require_relative 'rspec/resources'
 require_relative 'rspec/actions'

--- a/lib/fictium/rspec.rb
+++ b/lib/fictium/rspec.rb
@@ -4,6 +4,10 @@ require 'verbs'
 
 require_relative 'rspec/proxy_handler'
 
+require_relative 'rspec/autocomplete/action'
+require_relative 'rspec/autocomplete/example'
+require_relative 'rspec/autocomplete/resource'
+
 require_relative 'rspec/resources'
 require_relative 'rspec/actions'
 require_relative 'rspec/examples'

--- a/lib/fictium/rspec/actions.rb
+++ b/lib/fictium/rspec/actions.rb
@@ -24,6 +24,13 @@ module Fictium
         def deprecate!
           metadata[:fictium_action].deprecated = true
         end
+
+        def action_docs(description: nil, url:)
+          metadata[:fictium_action].docs = {}.tap do |docs|
+            docs[:url] = url
+            docs[:description] = description if description.present?
+          end
+        end
       end
     end
   end

--- a/lib/fictium/rspec/actions.rb
+++ b/lib/fictium/rspec/actions.rb
@@ -20,6 +20,10 @@ module Fictium
         def example(*args, **kwargs)
           Fictium::RSpec::Proxies::Example.new(self, args, kwargs)
         end
+
+        def deprecate!
+          metadata[:fictium_action].deprecated = true
+        end
       end
     end
   end

--- a/lib/fictium/rspec/actions.rb
+++ b/lib/fictium/rspec/actions.rb
@@ -5,7 +5,10 @@ module Fictium
 
       included do
         metadata[:fictium_action] = metadata[:fictium_resource].create_action
-        metadata[:fictium_action].description_attributes(metadata[:description])
+        Fictium::RSpec::Autocomplete::Action.description_attributes(
+          metadata[:fictium_action],
+          metadata[:description]
+        )
       end
 
       class_methods do

--- a/lib/fictium/rspec/autocomplete/action.rb
+++ b/lib/fictium/rspec/autocomplete/action.rb
@@ -1,0 +1,51 @@
+module Fictium
+  module RSpec
+    module Autocomplete
+      module Action
+        ACTION_NAME = /#([A-Z_]+)/i.freeze
+        DEFAULT_PATHS = {
+          create: '',
+          new: '/new',
+          show: '/{id}',
+          update: '/{id}',
+          destroy: '/{id}'
+        }.freeze
+        class << self
+          def description_attributes(action, description)
+            name = find_action_name(description)&.downcase
+            find_summary(action, name)
+            find_path(action, name)
+          end
+
+          private
+
+          def find_summary(action, name)
+            return if name.blank?
+
+            key = :"default_summary_for_#{name}"
+            summary_method = descriptors[key] || Fictium.configuration.unknown_action_descriptor
+            one_argument = summary_method.arity == 1
+            action.summary =
+              one_argument ? summary_method.call(action) : summary_method.call(action, name)
+          end
+
+          def descriptors
+            @descriptors ||= Fictium.configuration.default_action_descriptors || {}
+          end
+
+          def find_path(action, name)
+            return if name.blank?
+
+            key = name.to_sym
+            action.path = DEFAULT_PATHS[key].presence || "/{id}/#{name}"
+          end
+
+          def find_action_name(description)
+            match = description.match(ACTION_NAME)
+            match.presence && match[1]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fictium/rspec/autocomplete/action.rb
+++ b/lib/fictium/rspec/autocomplete/action.rb
@@ -4,6 +4,7 @@ module Fictium
       module Action
         ACTION_NAME = /#([A-Z_]+)/i.freeze
         DEFAULT_PATHS = {
+          index: '',
           create: '',
           new: '/new',
           show: '/{id}',
@@ -37,7 +38,7 @@ module Fictium
             return if name.blank?
 
             key = name.to_sym
-            action.path = DEFAULT_PATHS[key].presence || "/{id}/#{name}"
+            action.path = DEFAULT_PATHS[key] || "/{id}/#{name}"
           end
 
           def find_action_name(description)

--- a/lib/fictium/rspec/autocomplete/example.rb
+++ b/lib/fictium/rspec/autocomplete/example.rb
@@ -11,9 +11,16 @@ module Fictium
               content_type: response.content_type
             )
             process_http_request(example, response.request)
+            return unless example.default?
+
+            autocomplete_params.extract_from_response(example.action, response)
           end
 
           private
+
+          def autocomplete_params
+            Fictium::RSpec::Autocomplete::Params
+          end
 
           def process_http_request(example, request)
             example.request ||= {}
@@ -21,6 +28,13 @@ module Fictium
               content_type: request.content_type,
               body: request.body.string
             )
+            extract_method(example, request)
+            return unless example.default?
+
+            autocomplete_params.extract_from_request(example.action, request)
+          end
+
+          def extract_method(example, request)
             action = example.action
             action.method = request.method.downcase.to_sym if action.method.blank?
           end

--- a/lib/fictium/rspec/autocomplete/example.rb
+++ b/lib/fictium/rspec/autocomplete/example.rb
@@ -13,7 +13,7 @@ module Fictium
             process_http_request(example, response.request)
             return unless example.default?
 
-            autocomplete_params.extract_from_response(example.action, response)
+            autocomplete_params.extract_from_response(example, response)
           end
 
           private

--- a/lib/fictium/rspec/autocomplete/example.rb
+++ b/lib/fictium/rspec/autocomplete/example.rb
@@ -1,0 +1,31 @@
+module Fictium
+  module RSpec
+    module Autocomplete
+      module Example
+        class << self
+          def process_http_response(example, response)
+            example.response ||= {}
+            example.response.merge!(
+              status: response.status,
+              body: response.body,
+              content_type: response.content_type
+            )
+            process_http_request(example, response.request)
+          end
+
+          private
+
+          def process_http_request(example, request)
+            example.request ||= {}
+            example.request.merge!(
+              content_type: request.content_type,
+              body: request.body.string
+            )
+            action = example.action
+            action.method = request.method.downcase.to_sym if action.method.blank?
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fictium/rspec/autocomplete/params.rb
+++ b/lib/fictium/rspec/autocomplete/params.rb
@@ -1,0 +1,17 @@
+module Fictium
+  module RSpec
+    module Autocomplete
+      module Params
+        class << self
+          def extract_from_request(action, request)
+            # TODO: Extract from request
+          end
+
+          def extract_from_response(action, response)
+            # TODO: Extract from response
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fictium/rspec/autocomplete/params.rb
+++ b/lib/fictium/rspec/autocomplete/params.rb
@@ -28,7 +28,7 @@ module Fictium
           private
 
           def parse_request_query(params, _action, request)
-            parse_query_values(request.query_string).each do |key, value|
+            request.query_parameters.each do |key, value|
               params[key] ||= {}
               params[key].merge!(
                 example: value
@@ -71,14 +71,6 @@ module Fictium
 
           def ignored_header_groups
             Fictium.configuration.ignored_header_groups
-          end
-
-          def parse_query_values(query_string)
-            if defined?(Rack::Utils)
-              Rack::Utils.parse_nested_query(query_string.presence || '')
-            else
-              CGI.parse(query_string.presence || '')
-            end
           end
         end
       end

--- a/lib/fictium/rspec/autocomplete/params.rb
+++ b/lib/fictium/rspec/autocomplete/params.rb
@@ -14,7 +14,15 @@ module Fictium
           end
 
           def extract_from_response(example, response)
-            # TODO: Extract from response
+            example.headers ||= ActiveSupport::HashWithIndifferentAccess.new
+            response.headers.each do |name, value|
+              next unless valid_header?(name)
+
+              example.headers[name] ||= {}
+              example.headers[name].merge!(
+                example: value
+              )
+            end
           end
 
           private

--- a/lib/fictium/rspec/autocomplete/params.rb
+++ b/lib/fictium/rspec/autocomplete/params.rb
@@ -2,13 +2,75 @@ module Fictium
   module RSpec
     module Autocomplete
       module Params
+        REQUEST_SECTIONS = %i[query header path cookie].freeze
+        PATH_TEMPLATE = /{([A-Z_\-][A-Z0-9_\-]*)}/i.freeze
+
         class << self
           def extract_from_request(action, request)
-            # TODO: Extract from request
+            REQUEST_SECTIONS.each do |section|
+              action.params[section] ||= ActiveSupport::HashWithIndifferentAccess.new
+              send(:"parse_request_#{section}", action.params[section], action, request)
+            end
           end
 
-          def extract_from_response(action, response)
+          def extract_from_response(example, response)
             # TODO: Extract from response
+          end
+
+          private
+
+          def parse_request_query(params, _action, request)
+            parse_query_values(request.query_string).each do |key, value|
+              params[key] ||= {}
+              params[key].merge!(
+                example: value
+              )
+            end
+          end
+
+          def parse_request_header(params, _action, request)
+            request.headers.to_h.each do |name, value|
+              next unless valid_header?(name)
+
+              params[name] ||= {}
+              params[name].merge!(
+                example: value
+              )
+            end
+          end
+
+          def parse_request_path(params, action, _request)
+            action.full_path.scan(PATH_TEMPLATE).flatten.each do |name|
+              params[name] ||= {}
+              # TODO: Extract example from request
+            end
+          end
+
+          def parse_request_cookie(params, _action, request)
+            request.cookies.each do |key, value|
+              params[key] ||= {}
+              params[key].merge!(
+                example: value
+              )
+            end
+          end
+
+          def valid_header?(name)
+            return false if ignored_header_groups.any? { |group| name.downcase.start_with?(group) }
+
+            !Fictium.configuration.ignored_header_values.include?(name.downcase)
+          end
+
+          def ignored_header_groups
+            Fictium.configuration.ignored_header_groups
+          end
+
+          def parse_query_values(query_string)
+            if defined?(Rack::Utils)
+              Rack::Utils.parse_nested_query(query_string.presence || '')
+            else
+              CGI.parse(query_string.presence || '')
+            end
           end
         end
       end

--- a/lib/fictium/rspec/autocomplete/resource.rb
+++ b/lib/fictium/rspec/autocomplete/resource.rb
@@ -1,0 +1,20 @@
+module Fictium
+  module RSpec
+    module Autocomplete
+      module Resource
+        CONTROLLER_TERMINATION = /Controller$/.freeze
+
+        class << self
+          def name_attributes(resource, controller_name)
+            resource_path = controller_name.sub(CONTROLLER_TERMINATION, '').underscore
+            resource.base_path = "/#{resource_path}"
+            path_sections = resource_path.split('/')
+            plural = path_sections.last
+            resource.name = plural.singularize.humanize(capitalize: false)
+            resource.summary = Fictium.configuration.summary_format.call(plural)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fictium/rspec/examples.rb
+++ b/lib/fictium/rspec/examples.rb
@@ -33,6 +33,7 @@ module Fictium
         end
 
         def response_schema(obj)
+          metadata[:fictium_example].response ||= {}
           metadata[:fictium_example].response[:schema] =
             metadata[:fictium_schema].format(obj)
         end

--- a/lib/fictium/rspec/examples.rb
+++ b/lib/fictium/rspec/examples.rb
@@ -23,22 +23,18 @@ module Fictium
       class_methods do
         def default_example
           metadata[:fictium_example].default = true
+          metadata[:fictium_schema] = Fictium::SchemaEvaluator.new
         end
 
         def request_schema(obj = nil, ref: nil)
-          error_msg = 'request_schema needs a JSON-like object or a reference'
-          raise ArgumentError, error_msg if obj.blank? && ref.blank?
-
           metadata[:fictium_example].request ||= {}
-          metadata[:fictium_example].request[:schema] = ref || obj
+          metadata[:fictium_example].request[:schema] =
+            metadata[:fictium_schema].format(obj, ref: ref)
         end
 
         def response_schema(obj = nil, ref: nil)
-          error_msg = 'response_schema needs a JSON-like object or a reference'
-          raise ArgumentError, error_msg if obj.blank? && ref.blank?
-
-          metadata[:fictium_example].response ||= {}
-          metadata[:fictium_example].response[:schema] = ref || obj
+          metadata[:fictium_example].response[:schema] =
+            metadata[:fictium_schema].format(obj, ref: ref)
         end
 
         def require_request_body!

--- a/lib/fictium/rspec/examples.rb
+++ b/lib/fictium/rspec/examples.rb
@@ -12,7 +12,10 @@ module Fictium
 
           it 'documents the example' do
             expect(metadata[:fictium_example]).to be_present
-            metadata[:fictium_example].process_http_response(response)
+            Fictium::RSpec::Autocomplete::Example.process_http_response(
+              metadata[:fictium_example],
+              response
+            )
           end
         end
       end

--- a/lib/fictium/rspec/examples.rb
+++ b/lib/fictium/rspec/examples.rb
@@ -26,15 +26,15 @@ module Fictium
           metadata[:fictium_schema] = Fictium::SchemaEvaluator.new
         end
 
-        def request_schema(obj = nil, ref: nil)
+        def request_schema(obj)
           metadata[:fictium_example].request ||= {}
           metadata[:fictium_example].request[:schema] =
-            metadata[:fictium_schema].format(obj, ref: ref)
+            metadata[:fictium_schema].format(obj)
         end
 
-        def response_schema(obj = nil, ref: nil)
+        def response_schema(obj)
           metadata[:fictium_example].response[:schema] =
-            metadata[:fictium_schema].format(obj, ref: ref)
+            metadata[:fictium_schema].format(obj)
         end
 
         def require_request_body!

--- a/lib/fictium/rspec/examples.rb
+++ b/lib/fictium/rspec/examples.rb
@@ -21,6 +21,27 @@ module Fictium
         def default_example
           metadata[:fictium_example].default = true
         end
+
+        def request_schema(obj = nil, ref: nil)
+          error_msg = 'request_schema needs a JSON-like object or a reference'
+          raise ArgumentError, error_msg if obj.blank? && ref.blank?
+
+          metadata[:fictium_example].request ||= {}
+          metadata[:fictium_example].request[:schema] = ref || obj
+        end
+
+        def response_schema(obj = nil, ref: nil)
+          error_msg = 'response_schema needs a JSON-like object or a reference'
+          raise ArgumentError, error_msg if obj.blank? && ref.blank?
+
+          metadata[:fictium_example].response ||= {}
+          metadata[:fictium_example].response[:schema] = ref || obj
+        end
+
+        def require_request_body!
+          metadata[:fictium_example].request ||= {}
+          metadata[:fictium_example].request[:required] = true
+        end
       end
     end
   end

--- a/lib/fictium/rspec/resources.rb
+++ b/lib/fictium/rspec/resources.rb
@@ -5,7 +5,10 @@ module Fictium
 
       included do
         metadata[:fictium_resource] = Fictium::RSpec.document.create_resource
-        metadata[:fictium_resource].name_attributes(metadata[:described_class].name)
+        Fictium::RSpec::Autocomplete::Resource.name_attributes(
+          metadata[:fictium_resource],
+          metadata[:described_class].name
+        )
       end
 
       class_methods do

--- a/spec/controllers/books_controller_spec.rb
+++ b/spec/controllers/books_controller_spec.rb
@@ -1,4 +1,6 @@
 describe BooksController do
+  include_context 'with JSON API'
+
   # While automatically inferred, they can be also manually specified:
   base_path '/topics/{tag_id}/books'
   resource_name 'book'

--- a/spec/controllers/books_controller_spec.rb
+++ b/spec/controllers/books_controller_spec.rb
@@ -1,6 +1,6 @@
 describe BooksController do
   # While automatically inferred, they can be also manually specified:
-  base_path '/tags/:tag_id/books'
+  base_path '/tags/{tag_id}/books'
   resource_name 'book'
   resource_summary 'Lists all books for a specific tag.'
   resource_description <<~HEREDOC
@@ -14,6 +14,7 @@ describe BooksController do
 
     # This is also auto detected, but can be manually changed
     path ''
+    deprecate!
 
     let(:params) { { topic_id: topic_id } }
     let(:topic_id) { 1 }

--- a/spec/controllers/books_controller_spec.rb
+++ b/spec/controllers/books_controller_spec.rb
@@ -1,13 +1,13 @@
 describe BooksController do
   # While automatically inferred, they can be also manually specified:
-  base_path '/tags/{tag_id}/books'
+  base_path '/topics/{tag_id}/books'
   resource_name 'book'
-  resource_summary 'Lists all books for a specific tag.'
+  resource_summary 'Lists all books for a specific topic.'
   resource_description <<~HEREDOC
-    This will fail if the tag does not exists.
+    This will fail if the topic does not exists.
     The results are not paginated.
   HEREDOC
-  resource_tags 'tags', 'list'
+  resource_tags 'topics', 'list'
 
   describe action 'GET #index' do
     subject(:make_request) { get :index, params: params }

--- a/spec/controllers/books_controller_spec.rb
+++ b/spec/controllers/books_controller_spec.rb
@@ -15,6 +15,7 @@ describe BooksController do
     # This is also auto detected, but can be manually changed
     path ''
     deprecate!
+    action_docs url: 'http://docstoaction.com'
 
     let(:params) { { topic_id: topic_id } }
     let(:topic_id) { 1 }

--- a/spec/controllers/books_controller_spec.rb
+++ b/spec/controllers/books_controller_spec.rb
@@ -28,6 +28,7 @@ describe BooksController do
 
     describe example 'when a valid topic is given' do
       before do
+        request.headers.merge!('X-Extra-Header': 'Some value')
         make_request
       end
 

--- a/spec/controllers/books_controller_spec.rb
+++ b/spec/controllers/books_controller_spec.rb
@@ -2,7 +2,7 @@ describe BooksController do
   include_context 'with JSON API'
 
   # While automatically inferred, they can be also manually specified:
-  base_path '/topics/{tag_id}/books'
+  base_path '/topics/{topic_id}/books'
   resource_name 'book'
   resource_summary 'Lists all books for a specific topic.'
   resource_description <<~HEREDOC
@@ -13,6 +13,10 @@ describe BooksController do
 
   describe action 'GET #index' do
     subject(:make_request) { get :index, params: params }
+
+    params_in :path do
+      topic_id schema: { type: 'integer' }, description: "The topic's id"
+    end
 
     # This is also auto detected, but can be manually changed
     path ''

--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -1,4 +1,6 @@
 describe TopicsController do
+  include_context 'with JSON API'
+
   describe action 'GET #index' do
     subject(:make_request) { get :index }
 

--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -82,6 +82,17 @@ describe TopicsController do
 
       default_example
       require_request_body!
+      request_schema type: 'object', required: %w[tag], properties: {
+        tag: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string'
+            }
+          },
+          required: %w[name]
+        }
+      }
 
       before do
         make_request

--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -9,8 +9,6 @@ describe TopicsController do
         make_request
       end
 
-      default_example
-
       it 'responds with ok status' do
         expect(response).to have_http_status(:ok)
       end

--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -2,12 +2,22 @@ describe TopicsController do
   include_context 'with JSON API'
 
   describe action 'GET #index' do
-    subject(:make_request) { get :index }
+    subject(:make_request) { get :index, params: { limit: 10, page: 1 } }
+
+    params_in :cookie do
+      search_id schema: { type: 'string' }
+    end
+
+    params_in :query do
+      limit schema: { type: 'integer' }
+      page schema: { type: 'integer' }
+    end
 
     describe example 'when a valid request is processed' do
       default_example
 
       before do
+        request.cookies[:search_id] = '<Search Token>'
         make_request
       end
 
@@ -92,6 +102,10 @@ describe TopicsController do
           },
           required: %w[name]
         }
+      }
+      response_schema type: 'object', properties: {
+        id: { type: 'integer' },
+        name: { type: 'string' }
       }
 
       before do

--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -48,6 +48,7 @@ describe TopicsController do
       include_context 'with account login'
 
       default_example
+      require_request_body!
 
       let(:params) { { topic: { name: 'New Topic' } } }
 
@@ -78,6 +79,7 @@ describe TopicsController do
       include_context 'with account login'
 
       default_example
+      require_request_body!
 
       before do
         make_request

--- a/spec/evaluators/fictium/parameter_evaluator_spec.rb
+++ b/spec/evaluators/fictium/parameter_evaluator_spec.rb
@@ -2,21 +2,17 @@ describe Fictium::ParameterEvaluator do
   describe '#evaluate_params' do
     subject(:evaluator) { described_class.new }
 
-    let(:valid_params) do
-      ActiveSupport::HashWithIndifferentAccess.new(a: 2, b: 3, c: 4)
-    end
-
     context 'with a valid factory build' do
       before do
         evaluator.evaluate_params do
-          a { 2 }
-          b { 3 }
-          c { 4 }
+          a required: false
+          b schema: { ref: '/' }
+          c allow_empty: false
         end
       end
 
-      it 'evaluates parameters in a factory style' do
-        expect(evaluator.params).to eq valid_params
+      it 'returns the parameters as a hash with correct keys' do
+        expect(evaluator.params.keys).to match_array %w[a b c]
       end
     end
 
@@ -34,30 +30,12 @@ describe Fictium::ParameterEvaluator do
 
     before do
       evaluator.evaluate_params do
-        a { 2 }
+        a
       end
     end
 
-    it 'gets a given parameter by name' do
-      expect(evaluator[:a]).to eq(2)
-    end
-  end
-
-  describe '#respond_to?' do
-    subject(:evaluator) { described_class.new }
-
-    let(:method) { Faker::Name.name }
-
-    context 'when a block is given' do
-      it 'does not raise an error' do
-        expect { evaluator.send(method) {} }.not_to raise_error
-      end
-    end
-
-    context 'when no block is given' do
-      it 'raises a NoMethodError' do
-        expect { evaluator.send(method) }.to raise_error(NoMethodError)
-      end
+    it 'gets a given parameter by name as a hash' do
+      expect(evaluator[:a]).to be_a(Hash)
     end
   end
 end

--- a/spec/poros/fictium/action_spec.rb
+++ b/spec/poros/fictium/action_spec.rb
@@ -18,7 +18,7 @@ describe Fictium::Action do
   describe '#add_params_in' do
     before do
       action.add_params_in(:head) do
-        a { 3 }
+        a
       end
     end
 
@@ -27,7 +27,7 @@ describe Fictium::Action do
     end
 
     it 'adds the new parameters properly' do
-      expect(action[:head][:a]).to eq(3)
+      expect(action[:head][:a]).to be_a(Hash)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,3 +33,7 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 end
+
+Fictium.configure do |config|
+  config.fixture_path = File.join(__dir__, 'support', 'docs')
+end

--- a/spec/support/docs/servers.json
+++ b/spec/support/docs/servers.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "https://path.to.development.com"
+  },
+  {
+    "url": "https://path.to.staging.com"
+  }
+]

--- a/spec/support/shared_contexts.rb
+++ b/spec/support/shared_contexts.rb
@@ -3,3 +3,12 @@ shared_context 'with account login' do
     request.headers['Authorization'] = 'Bearer <token>'
   end
 end
+
+shared_context 'with JSON API' do
+  before do
+    request.headers.merge!(
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    )
+  end
+end


### PR DESCRIPTION
## Summary

After a lot of work, this finally generates some OpenAPI specification documents. It is the default importer, with all configured to make your API easy and quick.

## Notes

Be aware, this PR seems large, but it's because it has the schema validation for the OpenAPI 3.0.0 specification baked inside the gem.

I though of getting the schema using http, but, the gem has to work even if you don't have internet access at the time.