### PR TITLE
[Release 0.3.1] Modify changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@
 
 ## LOG
 
+### 0.3.1 (2019-11-12)
+
+New exporter: Postman.
+
+#### Changes
+
+- Add support for older Rails versions.
+
 ### 0.3.0 (2019-11-12)
 
 New exporter: Postman.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### 0.3.1 (2019-11-12)
 
-New exporter: Postman.
+Added support for rails 5.1
 
 #### Changes
 


### PR DESCRIPTION
## Summary

Allow older ruby projects to work with Fictium.

## Category

  **GEM RELEASE**

## Changelog

Added support for rails 5.1

#### Changes

- Add support for older Rails versions.