### PR TITLE
[FIX] Add error messages when fictium is not configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ To configure how this gem completes your documentation, you have some configurat
 
 ### RSpec Integration
 
-Just `require 'fictium/rspec'` in your spec helper and your RSpec test will include everything you need to work in your environment.
+Just `require 'fictium/rspec'` in your rails helper and your RSpec test will include everything you need to work in your environment.
+(be aware, the current version requires Rails to be previously loaded to work).
 
 At any test of type: :controller, you can just add the following helpers:
 

--- a/lib/fictium.rb
+++ b/lib/fictium.rb
@@ -25,5 +25,23 @@ module Fictium
     def configure
       yield configuration
     end
+
+    def validate_config!
+      raise missing_fixtures if configuration.fixture_path.blank?
+    end
+
+    private
+
+    def missing_fixtures
+      <<~HEREDOC
+        Fictium requires to configure your fixture_path first in order to run Fictium.
+
+        Add the following lines into your rails_helper.rb:
+
+        Fictium.configure do |config|
+          config.fixture_path = File.join(__dir__, 'support', 'docs')
+        end
+      HEREDOC
+    end
   end
 end

--- a/lib/fictium/rspec.rb
+++ b/lib/fictium/rspec.rb
@@ -33,6 +33,7 @@ RSpec.configure do |config|
   config.include Fictium::RSpec::Examples, fictium_example: true
 
   config.after(:suite) do
+    Fictium.validate_config!
     Fictium::RSpec.document.export
   end
 end

--- a/lib/fictium/rspec/autocomplete/params.rb
+++ b/lib/fictium/rspec/autocomplete/params.rb
@@ -1,3 +1,5 @@
+defined?(Rails) || raise('Rails is required to be loaded before "fictium/rspec" is required.')
+
 module Fictium
   module RSpec
     module Autocomplete

--- a/spec/fictium_spec.rb
+++ b/spec/fictium_spec.rb
@@ -10,4 +10,25 @@ describe Fictium do
       end
     end
   end
+
+  describe '.validate_config!' do
+    subject(:validation) { described_class.validate_config! }
+
+    let(:configuration) { described_class.configuration }
+
+    context 'when configuration is valid' do
+      it 'does not raise an error' do
+        expect { validation }.not_to raise_error
+      end
+    end
+
+    context 'when fixture_path is missing' do
+      it 'raises an error' do
+        old_config = configuration.fixture_path
+        configuration.fixture_path = nil
+        expect { validation }.to raise_error(StandardError)
+        configuration.fixture_path = old_config
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Add descriptive error messages when Fictium requires some configurations to be done.

## Category

  **FEATURE**
