### PR TITLE
Remove request body in swagger output if not present

### DIFF
--- a/lib/fictium/exporters/open_api/v3_exporter/example_formatter.rb
+++ b/lib/fictium/exporters/open_api/v3_exporter/example_formatter.rb
@@ -6,6 +6,8 @@ module Fictium
           responses[:default] = format(default_example)
           return if default_example.request[:content_type].blank?
 
+          return unless valid_request_body?(default_example.request[:body])
+
           operation[:requestBody] = {
             content: content_formatter.format(default_example.request)
           }
@@ -39,6 +41,12 @@ module Fictium
 
         def header_formatter
           @header_formatter ||= ParamFormatter.new(ignore_name: true, ignore_in: true)
+        end
+
+        private
+
+        def valid_request_body?(request_body)
+          request_body.present? && JSON.parse(request_body).present?
         end
       end
     end

--- a/spec/controllers/books_controller_spec.rb
+++ b/spec/controllers/books_controller_spec.rb
@@ -2,7 +2,7 @@ describe BooksController do
   include_context 'with JSON API'
 
   # While automatically inferred, they can be also manually specified:
-  base_path '/topics/:topic_id'
+  base_path '/topics/{topic_id}'
   resource_name 'book'
   resource_summary 'Handles books organized by tags.'
   resource_description <<~HEREDOC
@@ -57,6 +57,10 @@ describe BooksController do
 
     let(:params) { { id: book_id } }
     let(:book_id) { 1 }
+
+    params_in :path do
+      topic_id schema: { type: 'integer' }, description: "The topic's id"
+    end
 
     describe example 'when a valid book is given' do
       include_context 'with account login'

--- a/spec/controllers/books_controller_spec.rb
+++ b/spec/controllers/books_controller_spec.rb
@@ -2,7 +2,7 @@ describe BooksController do
   include_context 'with JSON API'
 
   # While automatically inferred, they can be also manually specified:
-  base_path '/topics/{topic_id}/books'
+  base_path '/topics/:topic_id'
   resource_name 'book'
   resource_summary 'Handles books organized by tags.'
   resource_description <<~HEREDOC


### PR DESCRIPTION
## Summary

PR for Issue #24 

The objective of this fix is to allow swagger output to avoid adding an unnecessary `requestBody` field for requests that don't have a request body.
This also fixes semantic errors that arise when viewing the swagger output from running the gems specs
<img width="1679" alt="Screen Shot 2020-01-15 at 10 17 04" src="https://user-images.githubusercontent.com/14864633/72438001-bcbcfe00-3782-11ea-8e6f-0e0de942613d.png">


I found an unrelated semantic error that I also fixed in this PR
<img width="1680" alt="Screen Shot 2020-01-15 at 10 18 51" src="https://user-images.githubusercontent.com/14864633/72438050-cd6d7400-3782-11ea-9099-c6c3a0ac44be.png">

Fixed swagger output
<img width="1621" alt="Screen Shot 2020-01-15 at 10 36 22" src="https://user-images.githubusercontent.com/14864633/72438097-e70ebb80-3782-11ea-9941-dc4a3e1c9a6a.png">


## Category
  **BUG PATCH**

## Changelog

* Removes unnecessary `requestBody` field for requests that don't have a request body
* Changes in specs to remove semantic errors in swagger output