### PR TITLE
Fix NoMethodError when spec fails

### DIFF
--- a/lib/fictium/exporters/api_blueprint_exporter/example_formatter.rb
+++ b/lib/fictium/exporters/api_blueprint_exporter/example_formatter.rb
@@ -10,7 +10,7 @@ module Fictium
       private
 
       def format_request(example)
-        return '' if example.request.blank?
+        return '' if example.try(:request).blank?
         return '' if example.request[:body].blank?
 
         result = request_head(example)
@@ -20,7 +20,7 @@ module Fictium
       end
 
       def format_response(example)
-        return '' if example.response.blank?
+        return '' if example.try(:response).blank?
 
         result = response_head(example)
         result += parse_http_object(example.response)


### PR DESCRIPTION
## Summary

An error occurred in an `after(:suite)` hook. NoMethodError: undefined method `request' for nil:NilClass

## Category

  **BUG PATCH**

## Changelog

- Fix an issue when attempting to export example after a controller spec failed